### PR TITLE
Fix last infection doesn't make client a zombie.

### DIFF
--- a/src/addons/sourcemod/scripting/zr/event.inc
+++ b/src/addons/sourcemod/scripting/zr/event.inc
@@ -128,7 +128,7 @@ public Action EventRoundEnd(Handle event, const char[] name, bool dontBroadcast)
     // Forward event to modules.
     WeaponsOnRoundEnd();
     RoundEndOnRoundEnd(reason);
-    InfectOnRoundEnd();
+    CreateTimer(0.5, InfectOnRoundEnd);
     SEffectsOnRoundEnd();
     RespawnOnRoundEnd();
     ZSpawnOnRoundEnd();

--- a/src/addons/sourcemod/scripting/zr/infect.inc
+++ b/src/addons/sourcemod/scripting/zr/infect.inc
@@ -543,7 +543,7 @@ void InfectOnRoundFreezeEnd()
 /**
  * The round is ending.
  */
-public Action InfectOnRoundEnd()
+public Action InfectOnRoundEnd(Handle Timer)
 {
     // Stop infect timers if running.
     ZREndTimer(g_tInfect);


### PR DESCRIPTION
This issue happens sometimes when the last human gets infected, but class attributes are not applied on them because bZombie[client] has been reset before applying. In Mapeadores ZR has make this method exclusive for csgo by hookevent "round_prestart" (https://github.com/Mapeadores/ZombieReloaded/commit/c3b2cd601a9ff676f324b3a490e004b9dbc41829)

I didn't expect this to happen on CS:S, but eventually it did happen today. Credits to @SparkyCloudy