### PR TITLE
feat: cvar to keep the original knife when player get infected

### DIFF
--- a/src/addons/sourcemod/scripting/zombiereloaded.sp
+++ b/src/addons/sourcemod/scripting/zombiereloaded.sp
@@ -45,7 +45,7 @@
 
 #include <sdkhooks>
 
-#define VERSION "3.10.4"
+#define VERSION "3.10.5"
 
 // Comment this line to exclude version info command. Enable this if you have
 // the repository and HG installed (Mercurial or TortoiseHG).

--- a/src/addons/sourcemod/scripting/zr/cvars.inc
+++ b/src/addons/sourcemod/scripting/zr/cvars.inc
@@ -83,6 +83,7 @@ enum struct CvarsList
     Handle CVAR_WEAPONS_ZMARKET_REBUY_AUTO;
     Handle CVAR_WEAPONS_ZMARKET_REBUY_PRIMARY;
     Handle CVAR_WEAPONS_ZMARKET_REBUY_SECONDARY;
+    Handle CVAR_WEAPONS_INFECT_REMOVE_KNIFE;
     Handle CVAR_HITGROUPS;
     Handle CVAR_DAMAGE_HITGROUPS;
     Handle CVAR_DAMAGE_BLOCK_FF;
@@ -307,6 +308,8 @@ void CvarsCreate()
     g_hCvarsList.CVAR_WEAPONS_ZMARKET_REBUY_PRIMARY     =    CreateConVar("zr_weapons_zmarket_rebuy_primary","P90",         "Default primary weapon. [Dependency: zr_weapons_zmarket&zr_weapons_zmarket_rebuy]");
     g_hCvarsList.CVAR_WEAPONS_ZMARKET_REBUY_SECONDARY   =    CreateConVar("zr_weapons_zmarket_rebuy_secondary","Elite",     "Default secondary weapon. [Dependency: zr_weapons_zmarket&zr_weapons_zmarket_rebuy]");
 
+    // Infecting
+    g_hCvarsList.CVAR_WEAPONS_INFECT_REMOVE_KNIFE       =    CreateConVar("zr_weapons_infect_removeknife",  "1",            "Give a new knife weapon when player is infected.");
 
     // ===========================
     // Hitgroups (core)

--- a/src/addons/sourcemod/scripting/zr/weapons/weapons.inc
+++ b/src/addons/sourcemod/scripting/zr/weapons/weapons.inc
@@ -883,6 +883,9 @@ stock void WeaponsRefreshClientWeapon(int client, WeaponsSlot slot)
  */
 stock void WeaponsRemoveAllClientWeapons(int client, bool weaponsdrop)
 {
+    // Give a new knife to player when he get infected
+    bool removeknife = GetConVarBool(g_hCvarsList.CVAR_WEAPONS_INFECT_REMOVE_KNIFE);
+
     // Get a list of all client's weapon indexes.
     int weapons[Slot_MAXSIZE];
     WeaponsGetClientWeapons(client, weapons);
@@ -901,8 +904,11 @@ stock void WeaponsRemoveAllClientWeapons(int client, bool weaponsdrop)
         if (view_as<WeaponsSlot>(x) == Slot_Melee)
         {
             // Strip knife.
-            RemovePlayerItem(client, weapons[x]);
-            AcceptEntityInput(weapons[x], "Kill");
+            if (removeknife)
+            {
+                RemovePlayerItem(client, weapons[x]);
+                AcceptEntityInput(weapons[x], "Kill");
+            }
             continue;
         }
 


### PR DESCRIPTION
Mapper (4Echo) asked for this feature, his map using knife as item. (Auto given when player spawn at the start of the round)
He made knife item usable by the owner, but it act different based on the owner team. 
Problem is knife was remove when human get infected. 

After some tests, we didn't find any issue if the owner keep the same knife when it get infected.
A cvar was the perfect balance, map can set the cvar to 0 to let player keep the same knife. 