### PR TITLE
fix(zmarketcommand): verify zmarket status

### DIFF
--- a/src/addons/sourcemod/scripting/zombiereloaded.sp
+++ b/src/addons/sourcemod/scripting/zombiereloaded.sp
@@ -45,7 +45,7 @@
 
 #include <sdkhooks>
 
-#define VERSION "3.10.11"
+#define VERSION "3.10.12"
 
 // Comment this line to exclude version info command. Enable this if you have
 // the repository and HG installed (Mercurial or TortoiseHG).

--- a/src/addons/sourcemod/scripting/zr/weapons/zmarket.inc
+++ b/src/addons/sourcemod/scripting/zr/weapons/zmarket.inc
@@ -138,11 +138,18 @@ void ZMarketLoad()
 
 public Action ZMarketBuyCommand(int client, int argc)
 {
+    bool zmarketenabled = GetConVarBool(g_hCvarsList.CVAR_WEAPONS_ZMARKET);
     char command[CONFIG_MAX_LENGTH];
     char zmarketcommand[CONFIG_MAX_LENGTH];
     char weaponname[WEAPONS_MAX_LENGTH];
 
     GetCmdArg(0, command, sizeof(command));
+
+    if (!zmarketenabled)
+    {
+        TranslationPrintToChat(client, "Feature is disabled");
+        return Plugin_Handled;
+    }
 
     int size = GetArraySize(arrayWeapons);
     for (int weaponindex = 0; weaponindex < size; weaponindex++)


### PR DESCRIPTION
Berke: `there is zr_weapons_zmarket cvar but its only checked when you type zmarket and not if you type sm_p90 etc`