### PR TITLE
fix(colors): full multicolors support

### DIFF
--- a/common/addons/sourcemod/translations/es/zombiereloaded.phrases.txt
+++ b/common/addons/sourcemod/translations/es/zombiereloaded.phrases.txt
@@ -6,7 +6,7 @@
 
 	"General round objective"
 	{
-		"es"		"El juego es @greenHumanos vs. Zombis@default, El objetivo de los zombis es infectar a todos los humanos. Traducido por @greenFranc1sco @defaultSteam: @greenfranug"
+		"es"		"El juego es {green}Humanos vs. Zombis{default}, El objetivo de los zombis es infectar a todos los humanos."
 	}
 
 	"General zmenu reminder"
@@ -209,7 +209,7 @@
 
 	"Classes random assignment"
 	{
-		"es"		"Has sido aleatoriamente asignado a la clase @green\"{1}\"."
+		"es"		"Has sido aleatoriamente asignado a la clase {green}\"{1}\"."
 	}
 
 	// Center Text/HUD
@@ -420,42 +420,42 @@
 
 	"Infect command infect successful"
 	{
-		"es"		"El jugador @green{1} @defaultha sido infectado con exito."
+		"es"		"El jugador {green}{1} {default}ha sido infectado con exito."
 	}
 
 	"Infect command infect successful public"
 	{
-		"es"		"@lgreen{1}@default has infected @green{2}@default." // TODO: Translate
+		"es"		"{lightgreen}{1}{default} has infected {green}{2}{default}." // TODO: Translate
 	}
 
 	"Infect command infect mother successful"
 	{
-		"es"		"El jugador @green{1} @defaultha sido infectado con exito como el zombi madre."
+		"es"		"El jugador {green}{1} {default}ha sido infectado con exito como el zombi madre."
 	}
 
 	"Infect command infect mother successful public"
 	{
-		"es"		"@lgreen{1}@default has infected @green{2}@default as the mother zombie." // TODO: Translate
+		"es"		"{lightgreen}{1}{default} has infected {green}{2}{default} as the mother zombie." // TODO: Translate
 	}
 
 	"Infect command infect unsuccessful"
 	{
-		"es"		"El jugador @green{1} @defaultya es un zombi."
+		"es"		"El jugador {green}{1} {default}ya es un zombi."
 	}
 
 	"Infect command human successful"
 	{
-		"es"		"El jugador @green{1} @defaultha vuelto a ser humano con exito."
+		"es"		"El jugador {green}{1} {default}ha vuelto a ser humano con exito."
 	}
 
 	"Infect command human successful public"
 	{
-		"es"		"@lgreen{1}@default has brought back @green{2}@default as a human." // TODO: Translate
+		"es"		"{lightgreen}{1}{default} has brought back {green}{2}{default} as a human." // TODO: Translate
 	}
 
 	"Infect command human unsuccessful"
 	{
-		"es"		"El jugador @green{1} @defaultya es un humano."
+		"es"		"El jugador {green}{1} {default}ya es un humano."
 	}
 
 	// ===========================
@@ -475,7 +475,7 @@
 
 	"Menu main title"
 	{
-		"es"		"Comandos ZR (Traducidos por Franc1sco Steam: franug):\nPrefijo de comando con \"{1}\" o \"{2}\" (calma) al escribir en el chat."
+		"es"		"Comandos ZR:\nPrefijo de comando con \"{1}\" o \"{2}\" (calma) al escribir en el chat."
 	}
 
 	"Menu main zadmin"
@@ -528,57 +528,57 @@
 
 	"Restrict weapon"
 	{
-		"es"		"El arma @green\"{1}\" @defaultha sido restringida."
+		"es"		"El arma {green}\"{1}\" {default}ha sido restringida."
 	}
 
 	"Unrestrict weapon"
 	{
-		"es"		"El arma @green\"{1}\" @defaultha sido autorizada."
+		"es"		"El arma {green}\"{1}\" {default}ha sido autorizada."
 	}
 
 	"Restrict weapon stopped"
 	{
-		"es"		"El arma @green\"{1}\" @defaultya esta restringida."
+		"es"		"El arma {green}\"{1}\" {default}ya esta restringida."
 	}
 
 	"Unrestrict weapon stopped"
 	{
-		"es"		"El arma @green\"{1}\" @default no tiene restricciones."
+		"es"		"El arma {green}\"{1}\" {default} no tiene restricciones."
 	}
 
 	"Restrict weapon type"
 	{
-		"es"		"Las armas del tipo @green\"{1}\" @defaultse han restringido."
+		"es"		"Las armas del tipo {green}\"{1}\" {default}se han restringido."
 	}
 
 	"Unrestrict weapon type"
 	{
-		"es"		"Las armas del tipo @green\"{1}\" @defaultse han autorizado."
+		"es"		"Las armas del tipo {green}\"{1}\" {default}se han autorizado."
 	}
 
 	"Restrict weapon type stopped"
 	{
-		"es"		"Las armas del tipo @green\"{1}\" @defaultestan ya todas restringidas."
+		"es"		"Las armas del tipo {green}\"{1}\" {default}estan ya todas restringidas."
 	}
 
 	"Unrestrict weapon type stopped"
 	{
-		"es"		"Las armas del tipo @green\"{1}\" @defaultno tienen restricciones."
+		"es"		"Las armas del tipo {green}\"{1}\" {default}no tienen restricciones."
 	}
 
 	"Restrict weapon untoggleable"
 	{
-		"es"		"El arma @green\"{1}\" @defaultno puede tener sus restricciones de alternancia."
+		"es"		"El arma {green}\"{1}\" {default}no puede tener sus restricciones de alternancia."
 	}
 
 	"Weapon invalid"
 	{
-		"es"		"El arma @green\"{1}\" @defaultes un nombre de (tipo) arma invalido."
+		"es"		"El arma {green}\"{1}\" {default}es un nombre de (tipo) arma invalido."
 	}
 
 	"Weapon is restricted"
 	{
-		"es"		"El arma @green{1} @defaultesta restringida."
+		"es"		"El arma {green}{1} {default}esta restringida."
 	}
 
 	// ZMarket
@@ -590,12 +590,12 @@
 
 	"Weapons zmarket purchase"
 	{
-		"es"		"Has comprado el arma @green{1}. @defaultSelecciona de nuevo el elemento si la municion es baja."
+		"es"		"Has comprado el arma {green}{1}. {default}Selecciona de nuevo el elemento si la municion es baja."
 	}
 
 	"Weapons zmarket purchase max"
 	{
-		"es"		"El arma @green{1} @defaulttiene un limite de compra de @green{2}@default.  Deberas esperar a tu proxima aparicion para poder volver a comprarlo."
+		"es"		"El arma {green}{1} {default}tiene un limite de compra de {green}{2}{default}.  Deberas esperar a tu proxima aparicion para poder volver a comprarlo."
 	}
 
 	"Weapons zmarket grenade max"
@@ -979,7 +979,7 @@
 
 	"ZSpawn command force successful public"
 	{
-		"es"		"@lgreen{1}@default has spawned @green{2}@default as a @lgreen{3}@default." // TODO: Translate
+		"es"		"{lightgreen}{1}{default} has spawned {green}{2}{default} as a {lightgreen}{3}{default}." // TODO: Translate
 	}
 
 	"ZSpawn command force unsuccessful"

--- a/common/addons/sourcemod/translations/no/zombiereloaded.phrases.txt
+++ b/common/addons/sourcemod/translations/no/zombiereloaded.phrases.txt
@@ -6,7 +6,7 @@
 
 	"General round objective"
 	{
-		"no"		"Spillet går ut på at @greenmennesker og zombier@default kjemper mot hverandre. Målet for zombiene er å infisere alle med kniven."
+		"no"		"Spillet går ut på at {green}mennesker og zombier{default} kjemper mot hverandre. Målet for zombiene er å infisere alle med kniven."
 	}
 
 	"General zmenu reminder"
@@ -208,7 +208,7 @@
 
 	"Classes random assignment"
 	{
-		"no"		"Du er blitt tilfeldig tildelt klassen @green\"{1}\"@default."
+		"no"		"Du er blitt tilfeldig tildelt klassen {green}\"{1}\"{default}."
 	}
 
 	// Center Text/HUD
@@ -419,42 +419,42 @@
 
 	"Infect command infect successful"
 	{
-		"no"		"@green{1}@default ble vellykket infisert."
+		"no"		"{green}{1}{default} ble vellykket infisert."
 	}
 
 	"Infect command infect successful public"
 	{
-		"no"		"@lgreen{1}@default has infected @green{2}@default." // TODO: Translate
+		"no"		"{lightgreen}{1}{default} has infected {green}{2}{default}." // TODO: Translate
 	}
 
 	"Infect command infect mother successful"
 	{
-		"no"		"@green{1}@default ble vellykket infisert som moderzombie."
+		"no"		"{green}{1}{default} ble vellykket infisert som moderzombie."
 	}
 
 	"Infect command infect mother successful public"
 	{
-		"no"		"@lgreen{1}@default has infected @green{2}@default as the mother zombie." // TODO: Translate
+		"no"		"{lightgreen}{1}{default} has infected {green}{2}{default} as the mother zombie." // TODO: Translate
 	}
 
 	"Infect command infect unsuccessful"
 	{
-		"no"		"@green{1}@default er allerede en zombie."
+		"no"		"{green}{1}{default} er allerede en zombie."
 	}
 
 	"Infect command human successful"
 	{
-		"no"		"@green{1}@default ble vellykket gjort om til et menneske."
+		"no"		"{green}{1}{default} ble vellykket gjort om til et menneske."
 	}
 
 	"Infect command human successful public"
 	{
-		"no"		"@lgreen{1}@default has brought back @green{2}@default as a human." // TODO: Translate
+		"no"		"{lightgreen}{1}{default} has brought back {green}{2}{default} as a human." // TODO: Translate
 	}
 
 	"Infect command human unsuccessful"
 	{
-		"no"		"@green{1}@default er allerede et menneske."
+		"no"		"{green}{1}{default} er allerede et menneske."
 	}
 
 	// ===========================
@@ -527,57 +527,57 @@
 
 	"Restrict weapon"
 	{
-		"no"		"Våpenet @green\"{1}\"@default ble sperret."
+		"no"		"Våpenet {green}\"{1}\"{default} ble sperret."
 	}
 
 	"Unrestrict weapon"
 	{
-		"no"		"Våpenet @green\"{1}\"@default er ikke lenger sperret."
+		"no"		"Våpenet {green}\"{1}\"{default} er ikke lenger sperret."
 	}
 
 	"Restrict weapon stopped"
 	{
-		"no"		"Våpenet @green\"{1}\"@default er allerede sperret."
+		"no"		"Våpenet {green}\"{1}\"{default} er allerede sperret."
 	}
 
 	"Unrestrict weapon stopped"
 	{
-		"no"		"Våpenet @green\"{1}\"@default er ikke sperret."
+		"no"		"Våpenet {green}\"{1}\"{default} er ikke sperret."
 	}
 
 	"Restrict weapon type"
 	{
-		"no"		"Våpentypen @green\"{1}\"@default er sperret."
+		"no"		"Våpentypen {green}\"{1}\"{default} er sperret."
 	}
 
 	"Unrestrict weapon type"
 	{
-		"no"		"Våpentypen @green\"{1}\"@default er ikke lenger sperret."
+		"no"		"Våpentypen {green}\"{1}\"{default} er ikke lenger sperret."
 	}
 
 	"Restrict weapon type stopped"
 	{
-		"no"		"Våpentypen @green\"{1}\"@default er allerede sperret."
+		"no"		"Våpentypen {green}\"{1}\"{default} er allerede sperret."
 	}
 
 	"Unrestrict weapon type stopped"
 	{
-		"no"		"Våpentypen @green\"{1}\"@default er ikke sperret."
+		"no"		"Våpentypen {green}\"{1}\"{default} er ikke sperret."
 	}
 
 	"Restrict weapon untoggleable"
 	{
-		"no"		"Våpenet @green\"{1}\"@default kan ikke sperres."
+		"no"		"Våpenet {green}\"{1}\"{default} kan ikke sperres."
 	}
 
 	"Weapon invalid"
 	{
-		"no"		"Våpenet eller våpentypen @green\"{1}\"@default er ugyldig."
+		"no"		"Våpenet eller våpentypen {green}\"{1}\"{default} er ugyldig."
 	}
 
 	"Weapon is restricted"
 	{
-		"no"		"Våpenet @green{1}@default er sperret."
+		"no"		"Våpenet {green}{1}{default} er sperret."
 	}
 
 	// ZMarket
@@ -589,12 +589,12 @@
 
 	"Weapons zmarket purchase"
 	{
-		"no"		"Du har kjøpt våpenet @green{1}@default. Velg gjenstanden igjen for å kjøpe mer ammunisjon."
+		"no"		"Du har kjøpt våpenet {green}{1}{default}. Velg gjenstanden igjen for å kjøpe mer ammunisjon."
 	}
 
 	"Weapons zmarket purchase max"
 	{
-		"no"		"Våpenet @green{1}@default har en kjøpegrense på @green{2}@default enheter. Vent til neste runde eller gjenoppliving."
+		"no"		"Våpenet {green}{1}{default} har en kjøpegrense på {green}{2}{default} enheter. Vent til neste runde eller gjenoppliving."
 	}
 
 	"Weapons zmarket grenade max"
@@ -979,7 +979,7 @@
 
 	"ZSpawn command force successful public"
 	{
-		"no"		"@lgreen{1}@default has spawned @green{2}@default as a @lgreen{3}@default." // TODO: Translate
+		"no"		"{lightgreen}{1}{default} has spawned {green}{2}{default} as a {lightgreen}{3}{default}." // TODO: Translate
 	}
 
 	"ZSpawn command force unsuccessful"

--- a/common/addons/sourcemod/translations/ru/zombiereloaded.phrases.txt
+++ b/common/addons/sourcemod/translations/ru/zombiereloaded.phrases.txt
@@ -6,7 +6,7 @@
 
 	"General round objective"
 	{
-		"ru"		"Битва @greenлюдей против зомби@default, цель для зомби — инфицировать всех людей, используя нож."
+		"ru"		"Битва {green}людей против зомби{default}, цель для зомби — инфицировать всех людей, используя нож."
 	}
 
 	"General zmenu reminder"
@@ -209,7 +209,7 @@
 
 	"Classes random assignment"
 	{
-		"ru"		"Вам был случайным образом присвоен класс @green\"{1}\"@default."
+		"ru"		"Вам был случайным образом присвоен класс {green}\"{1}\"{default}."
 	}
 
 	// Center Text/HUD
@@ -420,42 +420,42 @@
 
 	"Infect command infect successful"
 	{
-		"ru"		"Игрок @green{1}@default был успешно инфицирован."
+		"ru"		"Игрок {green}{1}{default} был успешно инфицирован."
 	}
 
 	"Infect command infect successful public"
 	{
-		"ru"		"@lgreen{1}@default сделал @green{2}@default зомби."
+		"ru"		"{lightgreen}{1}{default} сделал {green}{2}{default} зомби."
 	}
 
 	"Infect command infect mother successful"
 	{
-		"ru"		"Игрок @green{1}@default был успешно инфицирован и стал первым зомби."
+		"ru"		"Игрок {green}{1}{default} был успешно инфицирован и стал первым зомби."
 	}
 
 	"Infect command infect mother successful public"
 	{
-		"ru"		"@lgreen{1}@default сделал @green{2}@default первым зомби."
+		"ru"		"{lightgreen}{1}{default} сделал {green}{2}{default} первым зомби."
 	}
 
 	"Infect command infect unsuccessful"
 	{
-		"ru"		"Игрок @green{1}@default уже является зомби."
+		"ru"		"Игрок {green}{1}{default} уже является зомби."
 	}
 
 	"Infect command human successful"
 	{
-		"ru"		"Игрок @green{1}@default был успешно превращен обратно в человека."
+		"ru"		"Игрок {green}{1}{default} был успешно превращен обратно в человека."
 	}
 
 	"Infect command human successful public"
 	{
-		"ru"		"@lgreen{1}@default сделал @green{2}@default человеком."
+		"ru"		"{lightgreen}{1}{default} сделал {green}{2}{default} человеком."
 	}
 
 	"Infect command human unsuccessful"
 	{
-		"ru"		"Игрок@green{1}@default уже является человеком."
+		"ru"		"Игрок{green}{1}{default} уже является человеком."
 	}
 
 	// ===========================
@@ -528,57 +528,57 @@
 
 	"Restrict weapon"
 	{
-		"ru"		"Оружие @green\"{1}\"@default было запрещено."
+		"ru"		"Оружие {green}\"{1}\"{default} было запрещено."
 	}
 
 	"Unrestrict weapon"
 	{
-		"ru"		"Оружие @green\"{1}\"@default было разрешено."
+		"ru"		"Оружие {green}\"{1}\"{default} было разрешено."
 	}
 
 	"Restrict weapon stopped"
 	{
-		"ru"		"Оружие @green\"{1}\"@default уже является запрещённым."
+		"ru"		"Оружие {green}\"{1}\"{default} уже является запрещённым."
 	}
 
 	"Unrestrict weapon stopped"
 	{
-		"ru"		"Оружие @green\"{1}\"@default не является запрещённым."
+		"ru"		"Оружие {green}\"{1}\"{default} не является запрещённым."
 	}
 
 	"Restrict weapon type"
 	{
-		"ru"		"Оружие типа @green\"{1}\"@default было запрещено."
+		"ru"		"Оружие типа {green}\"{1}\"{default} было запрещено."
 	}
 
 	"Unrestrict weapon type"
 	{
-		"ru"		"Оружие типа @green\"{1}\"@default было разрешено."
+		"ru"		"Оружие типа {green}\"{1}\"{default} было разрешено."
 	}
 
 	"Restrict weapon type stopped"
 	{
-		"ru"		"Оружие типа @green\"{1}\"@default уже является запрещённым."
+		"ru"		"Оружие типа {green}\"{1}\"{default} уже является запрещённым."
 	}
 
 	"Unrestrict weapon type stopped"
 	{
-		"ru"		"Оружие типа @green\"{1}\"@default не является запрещённым."
+		"ru"		"Оружие типа {green}\"{1}\"{default} не является запрещённым."
 	}
 
 	"Restrict weapon untoggleable"
 	{
-		"ru"		"Оружие @green\"{1}\"@default не может быть запрещено."
+		"ru"		"Оружие {green}\"{1}\"{default} не может быть запрещено."
 	}
 
 	"Weapon invalid"
 	{
-		"ru"		"Оружие @green\"{1}\"@default не является правильным именем или типом оружия."
+		"ru"		"Оружие {green}\"{1}\"{default} не является правильным именем или типом оружия."
 	}
 
 	"Weapon is restricted"
 	{
-		"ru"		"Оружие @green{1}@default запрещено."
+		"ru"		"Оружие {green}{1}{default} запрещено."
 	}
 
 	// ZMarket
@@ -590,12 +590,12 @@
 
 	"Weapons zmarket purchase"
 	{
-		"ru"		"Вы приобрели оружие @green{1}@default. Выберите его ещё раз для покупки боеприпасов."
+		"ru"		"Вы приобрели оружие {green}{1}{default}. Выберите его ещё раз для покупки боеприпасов."
 	}
 
 	"Weapons zmarket purchase max"
 	{
-		"ru"		"Оружие @green{1}@default имеет лимит покупок @green{2}@default.  Попробуйте приобрести его в следующий раз."
+		"ru"		"Оружие {green}{1}{default} имеет лимит покупок {green}{2}{default}.  Попробуйте приобрести его в следующий раз."
 	}
 
 	"Weapons zmarket grenade max"
@@ -977,7 +977,7 @@
 
 	"ZSpawn command force successful public"
 	{
-		"ru"		"@lgreen{1}@default возродил @green{2}@default как @lgreen{3}@default."
+		"ru"		"{lightgreen}{1}{default} возродил {green}{2}{default} как {lightgreen}{3}{default}."
 	}
 
 	"ZSpawn command force unsuccessful"

--- a/common/addons/sourcemod/translations/zombiereloaded.phrases.txt
+++ b/common/addons/sourcemod/translations/zombiereloaded.phrases.txt
@@ -6,7 +6,7 @@
 
 	"General round objective"
 	{
-		"en"		"The game is @greenHumans vs. Zombies@default, the goal for zombies is to infect all humans by knifing them."
+		"en"		"The game is {green}Humans vs. Zombies{default}, the goal for zombies is to infect all humans by knifing them."
 	}
 
 	"General zmenu reminder"
@@ -219,7 +219,7 @@
 	"Classes random assignment"
 	{
 		"#format"	"{1:s}"
-		"en"		"You have randomly been assigned to the @green\"{1}\"@default class."
+		"en"		"You have randomly been assigned to the {green}\"{1}\"{default} class."
 	}
 
 	// Center Text/HUD
@@ -438,49 +438,49 @@
 	"Infect command infect successful"
 	{
 		"#format"	"{1:s}"
-		"en"		"Successfully infected @green{1}@default."
+		"en"		"Successfully infected {green}{1}{default}."
 	}
 
 	"Infect command infect successful public"
 	{
 		"#format"	"{1:s},{2:s}"
-		"en"		"@lgreen{1}@default has infected @green{2}@default."
+		"en"		"{lightgreen}{1}{default} has infected {green}{2}{default}."
 	}
 
 	"Infect command infect mother successful"
 	{
 		"#format"	"{1:s}"
-		"en"		"Successfully infected @green{1}@default as the mother zombie."
+		"en"		"Successfully infected {green}{1}{default} as the mother zombie."
 	}
 
 	"Infect command infect mother successful public"
 	{
 		"#format"	"{1:s},{2:s}"
-		"en"		"@lgreen{1}@default has infected @green{2}@default as the mother zombie."
+		"en"		"{lightgreen}{1}{default} has infected {green}{2}{default} as the mother zombie."
 	}
 
 	"Infect command infect unsuccessful"
 	{
 		"#format"	"{1:s}"
-		"en"		"Could not infect @green{1}@default."
+		"en"		"Could not infect {green}{1}{default}."
 	}
 
 	"Infect command human successful"
 	{
 		"#format"	"{1:s}"
-		"en"		"Successfully brought back @green{1}@default to life."
+		"en"		"Successfully brought back {green}{1}{default} to life."
 	}
 
 	"Infect command human successful public"
 	{
 		"#format"	"{1:s},{2:s}"
-		"en"		"@lgreen{1}@default has brought back @green{2}@default to life."
+		"en"		"{lightgreen}{1}{default} has brought back {green}{2}{default} to life."
 	}
 
 	"Infect command human unsuccessful"
 	{
 		"#format"	"{1:s}"
-		"en"		"Could not bring back @green{1}@default to life."
+		"en"		"Could not bring back {green}{1}{default} to life."
 	}
 
 	// ===========================
@@ -560,67 +560,67 @@
 	"Restrict weapon"
 	{
 		"#format"	"{1:s}"
-		"en"		"Weapon @green\"{1}\"@default has been restricted."
+		"en"		"Weapon {green}\"{1}\"{default} has been restricted."
 	}
 
 	"Unrestrict weapon"
 	{
 		"#format"	"{1:s}"
-		"en"		"Weapon @green\"{1}\"@default has been unrestricted."
+		"en"		"Weapon {green}\"{1}\"{default} has been unrestricted."
 	}
 
 	"Restrict weapon stopped"
 	{
 		"#format"	"{1:s}"
-		"en"		"Weapon @green\"{1}\"@default is already restricted."
+		"en"		"Weapon {green}\"{1}\"{default} is already restricted."
 	}
 
 	"Unrestrict weapon stopped"
 	{
 		"#format"	"{1:s}"
-		"en"		"Weapon @green\"{1}\"@default has no restrictions set."
+		"en"		"Weapon {green}\"{1}\"{default} has no restrictions set."
 	}
 
 	"Restrict weapon type"
 	{
 		"#format"	"{1:s}"
-		"en"		"Weapons of type @green\"{1}\"@default have been restricted."
+		"en"		"Weapons of type {green}\"{1}\"{default} have been restricted."
 	}
 
 	"Unrestrict weapon type"
 	{
 		"#format"	"{1:s}"
-		"en"		"Weapons of type @green\"{1}\"@default have been unrestricted."
+		"en"		"Weapons of type {green}\"{1}\"{default} have been unrestricted."
 	}
 
 	"Restrict weapon type stopped"
 	{
 		"#format"	"{1:s}"
-		"en"		"Weapons of type @green\"{1}\"@default are all already restricted."
+		"en"		"Weapons of type {green}\"{1}\"{default} are all already restricted."
 	}
 
 	"Unrestrict weapon type stopped"
 	{
 		"#format"	"{1:s}"
-		"en"		"Weapons of type @green\"{1}\"@default have no restrictions set."
+		"en"		"Weapons of type {green}\"{1}\"{default} have no restrictions set."
 	}
 
 	"Restrict weapon untoggleable"
 	{
 		"#format"	"{1:s}"
-		"en"		"Weapon @green\"{1}\"@default may not have its restrictions toggled."
+		"en"		"Weapon {green}\"{1}\"{default} may not have its restrictions toggled."
 	}
 
 	"Weapon invalid"
 	{
 		"#format"	"{1:s}"
-		"en"		"Weapon @green\"{1}\"@default is an invalid weapon (type) name."
+		"en"		"Weapon {green}\"{1}\"{default} is an invalid weapon (type) name."
 	}
 
 	"Weapon is restricted"
 	{
 		"#format"	"{1:s}"
-		"en"		"Weapon @green{1}@default is restricted."
+		"en"		"Weapon {green}{1}{default} is restricted."
 	}
 
 	// ZMarket
@@ -633,13 +633,13 @@
 	"Weapons zmarket purchase"
 	{
 		"#format"	"{1:s}"
-		"en"		"You have purchased weapon @green{1}.@default Select item again to buy ammo if you are low."
+		"en"		"You have purchased weapon {green}{1}.{default} Select item again to buy ammo if you are low."
 	}
 
 	"Weapons zmarket purchase max"
 	{
 		"#format"	"{1:s},{2:d}"
-		"en"		"Weapon @green{1}@default has a purchase limit of @green{2}@default.  Wait until you respawn to try again."
+		"en"		"Weapon {green}{1}{default} has a purchase limit of {green}{2}{default}.  Wait until you respawn to try again."
 	}
 
 	"Weapons zmarket grenade max"
@@ -1040,19 +1040,19 @@
 	"ZSpawn command force successful"
 	{
 		"#format"	"{1:s}"
-		"en"		"Successfully spawned @lgreen{1}@default."
+		"en"		"Successfully spawned {lightgreen}{1}{default}."
 	}
 
 	"ZSpawn command force successful public"
 	{
 		"#format"	"{1:s},{2:s},{3:s}"
-		"en"		"@lgreen{1}@default has spawned @green{2}@default as @lgreen{3}@default."
+		"en"		"{lightgreen}{1}{default} has spawned {green}{2}{default} as {lightgreen}{3}{default}."
 	}
 
 	"ZSpawn command force unsuccessful"
 	{
 		"#format"	"{1:s}"
-		"en"		"Could not zspawn @lgreen{1}@default."
+		"en"		"Could not zspawn {lightgreen}{1}{default}."
 	}
 
 	// ===========================
@@ -1120,13 +1120,13 @@
 	"ZTele command force successful"
 	{
 		"#format"	"{1:s}"
-		"en"		"Successfully teleported @lgreen{1}@default."
+		"en"		"Successfully teleported {lightgreen}{1}{default}."
 	}
 
 	"ZTele command force unsuccessful"
 	{
 		"#format"	"{1:s}"
-		"en"		"Could not teleport @lgreen{1}@default."
+		"en"		"Could not teleport {lightgreen}{1}{default}."
 	}
 
 	// ===========================
@@ -1198,7 +1198,7 @@
 	"Set_Countdown_Volume"
 	{
 		"#format"	"{1:d}"
-		"en"		"Set Countdown Volume to @lgreen{1:d}%."
+		"en"		"Set Countdown Volume to {lightgreen}{1:d}%."
 	}
 
 	// Zombie Voice
@@ -1221,7 +1221,7 @@
 	"Set_ZombieVoice_Volume"
 	{
 		"#format"	"{1:d}"
-		"en"		"Set Zombie Voice Volume to @lgreen{1:d}%."
+		"en"		"Set Zombie Voice Volume to {lightgreen}{1:d}%."
 	}
 
 	// Ambient
@@ -1244,7 +1244,7 @@
 	"Set_Ambient_Volume"
 	{
 		"#format"	"{1:d}"
-		"en"		"Set Ambient Volume to @lgreen{1:d}%."
+		"en"		"Set Ambient Volume to {lightgreen}{1:d}%."
 	}
 
 	// ===========================

--- a/src/addons/sourcemod/scripting/zombiereloaded.sp
+++ b/src/addons/sourcemod/scripting/zombiereloaded.sp
@@ -32,6 +32,7 @@
 #include <sdktools>
 #include <clientprefs>
 #include <cstrike>
+#include <multicolors>
 #define INCLUDED_BY_ZOMBIERELOADED
 #include <zombiereloaded>
 #undef INCLUDED_BY_ZOMBIERELOADED

--- a/src/addons/sourcemod/scripting/zombiereloaded.sp
+++ b/src/addons/sourcemod/scripting/zombiereloaded.sp
@@ -32,7 +32,6 @@
 #include <sdktools>
 #include <clientprefs>
 #include <cstrike>
-#tryinclude <multicolors>
 #define INCLUDED_BY_ZOMBIERELOADED
 #include <zombiereloaded>
 #undef INCLUDED_BY_ZOMBIERELOADED
@@ -45,7 +44,7 @@
 
 #include <sdkhooks>
 
-#define VERSION "3.10.15"
+#define VERSION "3.10.16"
 
 // Comment this line to exclude version info command. Enable this if you have
 // the repository and HG installed (Mercurial or TortoiseHG).

--- a/src/addons/sourcemod/scripting/zr/translation.inc
+++ b/src/addons/sourcemod/scripting/zr/translation.inc
@@ -40,16 +40,6 @@
 #define TRANSLATION_PHRASE_PREFIX "[ZR]"
 
 /**
- * @section Text color chars.
- */
-#define TRANSLATION_TEXT_COLOR_DEFAULT "\x01"
-#define TRANSLATION_TEXT_COLOR_LGREEN "\x03"
-#define TRANSLATION_TEXT_COLOR_GREEN "\x04"
-/**
- * @endsection
- */
-
-/**
  * Load translations file here.
  */
 void TranslationInit()
@@ -88,17 +78,12 @@ stock void TranslationPluginFormatString(char[] text, int maxlen, bool color = t
     if (color)
     {
         // Format prefix onto the string.
-        Format(text, maxlen, "@green%s @default%s", TRANSLATION_PHRASE_PREFIX, text);
+        Format(text, maxlen, "{green}%s {default}%s", TRANSLATION_PHRASE_PREFIX, text);
 
-        // Replace color tokens with CS:S color chars.
-        ReplaceString(text, maxlen, "@default", TRANSLATION_TEXT_COLOR_DEFAULT);
-        ReplaceString(text, maxlen, "@lgreen", TRANSLATION_TEXT_COLOR_LGREEN);
-        ReplaceString(text, maxlen, "@green", TRANSLATION_TEXT_COLOR_GREEN);
-
-        // Backwards compatibility with multicolors.inc
-        ReplaceString(text, maxlen, "{default}", TRANSLATION_TEXT_COLOR_DEFAULT);
-        ReplaceString(text, maxlen, "{lightgreen}", TRANSLATION_TEXT_COLOR_LGREEN);
-        ReplaceString(text, maxlen, "{green}", TRANSLATION_TEXT_COLOR_GREEN);
+        // Backwards compatibility with old color codes.
+        ReplaceString(text, maxlen, "@default", "{default}");
+        ReplaceString(text, maxlen, "@lgreen", "{lightgreen}");
+        ReplaceString(text, maxlen, "@green", "{green}");
 
         return;
     }
@@ -126,7 +111,7 @@ stock void TranslationPrintToChat(int client, any ...)
     TranslationPluginFormatString(translation, sizeof(translation));
 
     // Print translated phrase to client.
-    PrintToChat(client, translation);
+    CPrintToChat(client, translation);
 }
 
 /**
@@ -180,7 +165,7 @@ stock void TranslationPrintToChatAll(bool server, bool admin, any ...)
         TranslationPluginFormatString(translation, sizeof(translation));
 
         // Print translated phrase to client.
-        PrintToChat(x, translation);
+        CPrintToChat(x, translation);
     }
 }
 
@@ -241,7 +226,7 @@ stock void TranslationPrintToChatAllExcept(bool server, bool admin, int client, 
         TranslationPluginFormatString(translation, sizeof(translation));
 
         // Print translated phrase to client.
-        PrintToChat(x, translation);
+        CPrintToChat(x, translation);
     }
 }
 

--- a/src/addons/sourcemod/scripting/zr/translation.inc
+++ b/src/addons/sourcemod/scripting/zr/translation.inc
@@ -90,19 +90,15 @@ stock void TranslationPluginFormatString(char[] text, int maxlen, bool color = t
         // Format prefix onto the string.
         Format(text, maxlen, "@green%s @default%s", TRANSLATION_PHRASE_PREFIX, text);
 
-        // Replace color tokens with game color chars.
-    #if defined _multicolors_included
-        ReplaceString(text, maxlen, "@default", "{default}");
-        ReplaceString(text, maxlen, "@lgreen", "{lightgreen}");
-        ReplaceString(text, maxlen, "@green", "{green}");
-
-        CFormatColor(text, maxlen, 0);
-        CAddWhiteSpace(text, maxlen);
-    #else
+        // Replace color tokens with CS:S color chars.
         ReplaceString(text, maxlen, "@default", TRANSLATION_TEXT_COLOR_DEFAULT);
         ReplaceString(text, maxlen, "@lgreen", TRANSLATION_TEXT_COLOR_LGREEN);
         ReplaceString(text, maxlen, "@green", TRANSLATION_TEXT_COLOR_GREEN);
-    #endif
+
+        // Backwards compatibility with multicolors.inc
+        ReplaceString(text, maxlen, "{default}", TRANSLATION_TEXT_COLOR_DEFAULT);
+        ReplaceString(text, maxlen, "{lightgreen}", TRANSLATION_TEXT_COLOR_LGREEN);
+        ReplaceString(text, maxlen, "{green}", TRANSLATION_TEXT_COLOR_GREEN);
 
         return;
     }


### PR DESCRIPTION
Since the plugin only support CS:S now, no need to keep support for multicolors, color can stay hardcoded.
fix https://github.com/srcdslab/sm-plugin-zombiereloaded/issues/59