### PR TITLE
Fix weapon name check and improve attacker validation

### DIFF
--- a/src/addons/sourcemod/scripting/zr/damage.inc
+++ b/src/addons/sourcemod/scripting/zr/damage.inc
@@ -229,11 +229,6 @@ public Action DamageOnTakeDamage(int client, int &attacker, int &inflictor, floa
     char classname[64];
     GetEdictClassname(inflictor, classname, sizeof(classname));
 
-    // Get the attacker weapon name.
-    char weaponname[64];
-    if (attacker > 0 && attacker <= MaxClients && IsClientInGame(attacker))
-        GetClientWeapon(attacker, weaponname, sizeof(weaponname));
-
     // If entity is a trigger, then allow damage. (Map is damaging client)
     if (StrContains(classname, "trigger") > -1)
     {
@@ -247,6 +242,12 @@ public Action DamageOnTakeDamage(int client, int &attacker, int &inflictor, floa
     if (action > -1)
     {
         return view_as<Action>(action);
+    }
+
+    // If attacker is invalid, then stop.
+    if (attacker <= 0 || attacker > MaxClients || !IsClientInGame(attacker))
+    {
+        return Plugin_Continue;
     }
 
     // Client was shot or knifed.
@@ -276,7 +277,11 @@ public Action DamageOnTakeDamage(int client, int &attacker, int &inflictor, floa
             return Plugin_Continue;
         }
 
-        if (!clientzombie && attackerzombie && !(strcmp(weaponname, "weapon_bayonet", false) == 0 || strncmp(weaponname, "weapon_knife", 12) == 0))
+        // Get the attacker weapon name.
+        char weaponname[64];
+        GetClientWeapon(attacker, weaponname, sizeof(weaponname));
+
+        if (!clientzombie && attackerzombie && !(strncmp(weaponname, "weapon_knife", 12) == 0))
         {
             damage = 1.0;
             return Plugin_Changed;

--- a/src/addons/sourcemod/scripting/zr/damage.inc
+++ b/src/addons/sourcemod/scripting/zr/damage.inc
@@ -244,12 +244,6 @@ public Action DamageOnTakeDamage(int client, int &attacker, int &inflictor, floa
         return view_as<Action>(action);
     }
 
-    // If attacker is invalid, then stop.
-    if (attacker <= 0 || attacker > MaxClients || !IsClientInGame(attacker))
-    {
-        return Plugin_Continue;
-    }
-
     // Client was shot or knifed.
     if (damagetype & DMG_BULLET || damagetype & DMG_NEVERGIB)
     {

--- a/src/addons/sourcemod/scripting/zr/hgversion.h.inc
+++ b/src/addons/sourcemod/scripting/zr/hgversion.h.inc
@@ -4,7 +4,7 @@
 #define ZR_VER_BRANCH           "master"
 #define ZR_VER_MAJOR            "3"
 #define ZR_VER_MINOR            "12"
-#define ZR_VER_PATCH            "3"
+#define ZR_VER_PATCH            "4"
 #define ZR_VERSION              ZR_VER_MAJOR..."."...ZR_VER_MINOR..."."...ZR_VER_PATCH
 #define ZR_VER_LICENSE          "GNU GPL, Version 3"
 #define ZR_VER_DATE             "Wed Jan 30 09:38:56 CEST 2025"


### PR DESCRIPTION
- Moved attacker validation to prevent potential issues with invalid clients (solve #83 ? )
- Relocated weapon name retrieval to only occur when needed
- Remove CSGO knife weapon check with bayonet condition