### PR TITLE
fix(startup): Reload critical configs on first server start (#86)

### DIFF
--- a/src/addons/sourcemod/scripting/zombiereloaded.sp
+++ b/src/addons/sourcemod/scripting/zombiereloaded.sp
@@ -114,6 +114,7 @@
 #include "zr/api/api"
 
 bool g_bLate = false;
+bool g_bFirstLoad = true;
 bool g_bServerStarted = false;
 
 /**
@@ -264,6 +265,19 @@ public void OnConfigsExecuted()
     ClassOnConfigsExecuted();
     ClassLoad();
     VolLoad();
+
+    // After all configurations have been loaded, reload critical configs on the first startup
+    // https://github.com/srcdslab/sm-plugin-zombiereloaded/issues/86
+    if (g_bFirstLoad && g_bServerStarted)
+    {
+        char configalias[CONFIG_MAX_LENGTH];
+        for (int x = 0; x < sizeof(g_ConfigData); x++)
+        {
+            ConfigReloadConfig(view_as<ConfigFile>(x));
+            ConfigGetConfigAlias(view_as<ConfigFile>(x), configalias, sizeof(configalias));
+        }
+        g_bFirstLoad = false;
+    }
 
     // Forward event to modules. (OnModulesLoaded)
     ConfigOnModulesLoaded();

--- a/src/addons/sourcemod/scripting/zr/hgversion.h.inc
+++ b/src/addons/sourcemod/scripting/zr/hgversion.h.inc
@@ -4,7 +4,7 @@
 #define ZR_VER_BRANCH           "master"
 #define ZR_VER_MAJOR            "3"
 #define ZR_VER_MINOR            "12"
-#define ZR_VER_PATCH            "4"
+#define ZR_VER_PATCH            "5"
 #define ZR_VERSION              ZR_VER_MAJOR..."."...ZR_VER_MINOR..."."...ZR_VER_PATCH
 #define ZR_VER_LICENSE          "GNU GPL, Version 3"
 #define ZR_VER_DATE             "Wed Jan 30 09:38:56 CEST 2025"


### PR DESCRIPTION
This PR implements an automatic reload of all critical configurations after the initial loading sequence is complete.
When the server detects it's the first startup:

1. It waits until all regular configurations are loaded
2. Then reloads all critical configuration files:
	- Models
	- Downloads
	- Classes
	- Weapons
	- Hitgroups

## Benefits
Fixes plugin functionality without requiring a map change
Only runs once at server startup (no performance impact during normal operation)
Uses the existing configuration system for reliable reloading

Should fix #86