### PR TITLE
feat(api): add weapon restrict per client

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ Find all cvars details on [online docs](https://srcdslab.github.io/sm-plugin-zom
 - zr_classes_overlay_default        - "1" -                                 Default class overlay toggle state set on connecting player.
 - zr_weapons                        - "1" -                                 Enable weapons module, disabling this will disable any weapons-related features. (weapon restrictions, weapon knockback multipliers, etc)
 - zr_weapons_restrict               - "1" -                                 Enable weapon restriction module, disabling this will disable weapon restriction commands.
+- zr_weapons_restrict_perplayer               - "0" -                       Enable weapon restriction per-player module. [Dependency: zr_weapons_restrict]
 - zr_weapons_restrict_endequip      - "1" -                                 Restricts zombies from picking up weapons after the round has ended but before the next round has begun.
 - zr_weapons_zmarket                - "1" -                                 Allow player to buy from a list of weapons in the weapons config.
 - zr_weapons_zmarket_buyzone        - "1" -                                 Requires player to be inside a buyzone to use ZMarket. [Dependency: zr_weapons_zmarket]

--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ Find all cvars details on [online docs](https://srcdslab.github.io/sm-plugin-zom
 - zr_classes_overlay_default        - "1" -                                 Default class overlay toggle state set on connecting player.
 - zr_weapons                        - "1" -                                 Enable weapons module, disabling this will disable any weapons-related features. (weapon restrictions, weapon knockback multipliers, etc)
 - zr_weapons_restrict               - "1" -                                 Enable weapon restriction module, disabling this will disable weapon restriction commands.
-- zr_weapons_restrict_perplayer               - "0" -                       Enable weapon restriction per-player module. [Dependency: zr_weapons_restrict]
+- zr_weapons_restrict_perplayer     - "0" -                                 Enable weapon restriction per-player module. [Dependency: zr_weapons_restrict]
 - zr_weapons_restrict_endequip      - "1" -                                 Restricts zombies from picking up weapons after the round has ended but before the next round has begun.
 - zr_weapons_zmarket                - "1" -                                 Allow player to buy from a list of weapons in the weapons config.
 - zr_weapons_zmarket_buyzone        - "1" -                                 Requires player to be inside a buyzone to use ZMarket. [Dependency: zr_weapons_zmarket]

--- a/common/addons/sourcemod/translations/chi/zombiereloaded.phrases.txt
+++ b/common/addons/sourcemod/translations/chi/zombiereloaded.phrases.txt
@@ -769,6 +769,21 @@
 		"chi"		"弹药"
 	}
 
+	"Weapons menu restrict per player"
+	{
+		"chi"		"玩家武器限制"
+	}
+
+	"Weapons menu restrict per player title"
+	{
+		"chi"		"玩家武器限制\n选择一名玩家"
+	}
+
+	"Weapons menu restrict types per-player title"
+	{
+		"chi"		"玩家武器限制\n玩家：{1}\n选择武器类型"
+	}
+
 	// ===========================
 	// Hitgroups (core)
 	// ===========================

--- a/common/addons/sourcemod/translations/es/zombiereloaded.phrases.txt
+++ b/common/addons/sourcemod/translations/es/zombiereloaded.phrases.txt
@@ -771,6 +771,21 @@
 		"es"		"Municion"
 	}
 
+	"Weapons menu restrict per player"
+	{
+		"es"		"Restricción de armas de los jugadores"
+	}
+
+	"Weapons menu restrict per player title"
+	{
+		"es"		"Restricción de armas de los jugadores\nSeleccionar un jugador"
+	}
+
+	"Weapons menu restrict types per-player title"
+	{
+		"es"		"Restricción de armas de los jugadores\nJugador: {1}\nSeleccionar un tipo de arma"
+	}
+
 	// ===========================
 	// Hitgroups (core)
 	// ===========================

--- a/common/addons/sourcemod/translations/fr/zombiereloaded.phrases.txt
+++ b/common/addons/sourcemod/translations/fr/zombiereloaded.phrases.txt
@@ -769,6 +769,21 @@
 		"fr"		"Munitions"
 	}
 
+	"Weapons menu restrict per player"
+	{
+		"fr"		"Restriction d'armes des joueurs"
+	}
+
+	"Weapons menu restrict per player title"
+	{
+		"fr"		"Restriction d'armes des joueurs\nSélectionnez un joueur"
+	}
+
+	"Weapons menu restrict types per-player title"
+	{
+		"fr"		"Restriction d'armes des joueurs\nJoueur : {1}\nSélectionnez un type d'arme"
+	}
+
 	// ===========================
 	// Hitgroups (core)
 	// ===========================

--- a/common/addons/sourcemod/translations/no/zombiereloaded.phrases.txt
+++ b/common/addons/sourcemod/translations/no/zombiereloaded.phrases.txt
@@ -770,6 +770,21 @@
 		"no"		"Ammunisjon"
 	}
 
+	"Weapons menu restrict per player"
+	{
+		"no"		"Spillernes våpenbegrensning"
+	}
+
+	"Weapons menu restrict per player title"
+	{
+		"no"		"Spillernes våpenbegrensning\nVelg en spiller"
+	}
+
+	"Weapons menu restrict types per-player title"
+	{
+		"no"		"Spillernes våpenbegrensning\nSpiller: {1}\nVelg en våpentype"
+	}
+
 	// ===========================
 	// Hitgroups (core)
 	// ===========================

--- a/common/addons/sourcemod/translations/ru/zombiereloaded.phrases.txt
+++ b/common/addons/sourcemod/translations/ru/zombiereloaded.phrases.txt
@@ -769,6 +769,21 @@
 		"ru"		"Боеприпасы"
 	}
 
+	"Weapons menu restrict per player"
+	{
+		"ru"		"Ограничения на оружие игроков"
+	}
+
+	"Weapons menu restrict per player title"
+	{
+		"ru"		"Ограничения на оружие игроков\nВыберите игрока"
+	}
+
+	"Weapons menu restrict types per-player title"
+	{
+		"ru"		"Ограничения на оружие игроков\nИгрок: {1}\nВыберите тип оружия"
+	}
+	
 	// ===========================
 	// Hitgroups (core)
 	// ===========================

--- a/common/addons/sourcemod/translations/zho/zombiereloaded.phrases.txt
+++ b/common/addons/sourcemod/translations/zho/zombiereloaded.phrases.txt
@@ -769,6 +769,21 @@
 		"zho"		"彈藥"
 	}
 
+	"Weapons menu restrict per player"
+	{
+		"zho"		"玩家武器限制"
+	}
+
+	"Weapons menu restrict per player title"
+	{
+		"zho"		"玩家武器限制\n選擇一名玩家"
+	}
+
+	"Weapons menu restrict types per-player title"
+	{
+		"zho"		"玩家武器限制\n玩家：{1}\n選擇武器類型"
+	}
+
 	// ===========================
 	// Hitgroups (core)
 	// ===========================

--- a/common/addons/sourcemod/translations/zombiereloaded.phrases.txt
+++ b/common/addons/sourcemod/translations/zombiereloaded.phrases.txt
@@ -748,6 +748,22 @@
 		"en"		"Buyzone Only - {1}"
 	}
 
+	"Weapons menu restrict per player"
+	{
+		"en"		"Players Weapons Restriction"
+	}
+
+	"Weapons menu restrict per player title"
+	{
+		"en"		"Players Weapons Restriction\nSelect a player"
+	}
+
+	"Weapons menu restrict types per-player title"
+	{
+		"#format"	"{1:N}"
+		"en"		"Players Weapons Restriction\nPlayer: {1}\nSelect a weapons type"
+	}
+
 	// Menu (ZMarket)
 
 	"Weapons menu zmarket main title"

--- a/common/addons/sourcemod/translations/zombiereloaded.phrases.txt
+++ b/common/addons/sourcemod/translations/zombiereloaded.phrases.txt
@@ -761,7 +761,7 @@
 	"Weapons menu restrict types per-player title"
 	{
 		"#format"	"{1:N}"
-		"en"		"Players Weapons Restriction\nPlayer: {1}\nSelect a weapons type"
+		"en"		"Players Weapons Restriction\nPlayer: {1}\nSelect a weapon type"
 	}
 
 	// Menu (ZMarket)

--- a/docs/index.html
+++ b/docs/index.html
@@ -2497,6 +2497,18 @@ file, or on a per-map basis with map configuration files.</p>
 	</tr>
 	
 	<tr>
+		<td class="commandheader">zr_weapons_restrict_perplayer</td>
+		<td class="commandheader">0</td>
+	</tr>
+	<tr>
+		<td class="indent" colspan="2">
+			<p>Enable weapon restriction per-player module. [Dependency: zr_weapons_restrict].</p>
+			<p>Options:<br />
+			0 or 1</p>
+		</td>
+	</tr>
+
+	<tr>
 		<td class="commandheader">zr_weapons_restrict_endequip</td>
 		<td class="commandheader">1</td>
 	</tr>

--- a/src/addons/sourcemod/scripting/include/zr/weapons.zr.inc
+++ b/src/addons/sourcemod/scripting/include/zr/weapons.zr.inc
@@ -117,3 +117,36 @@ native bool ZR_GetWeaponZMarketCommand(const char[] weapon, char[] command, int 
  * @return              True if weapon exists and value is valid, false otherwise.
  */
 native bool ZR_SetWeaponKnockback(const char[] weapon, float value);
+
+/**
+ * Set all wepaon restrict array for the specified client.
+ * @param client    The client index.
+ * @param value	   The restrict value
+ * @noreturn        
+ */
+native void ZR_SetClientWeaponRestrictAll(int client, bool value);
+
+/**
+ * Set all wepaon restrict array for all clients.
+ * @param client    The client index.
+ * @param value	   The restrict value
+ * @noreturn        
+ */
+native void ZR_SetAllRestrictAll(bool value);
+
+/**
+ * Set weapon restrict value to a specific client.
+ * @param client    		 The client index.
+ * @param returntarget    The weapon or weapon type name.
+ * @param value	   		 The restrict value
+ * @return				 True on success, false otherwise            
+ */
+native bool ZR_SetClientWeaponRestrict(int client, const char[] returntarget, bool value);
+
+/**
+ * Set weapon restrict value to all clients.
+ * @param returntarget    The weapon or weapon type name.
+ * @param value	   		 The restrict value
+ * @return				 True on success, false otherwise        
+ */
+native bool ZR_SetAllWeaponRestrict(const char[] returntarget, bool value);

--- a/src/addons/sourcemod/scripting/include/zr/weapons.zr.inc
+++ b/src/addons/sourcemod/scripting/include/zr/weapons.zr.inc
@@ -128,7 +128,6 @@ native void ZR_SetClientWeaponRestrictAll(int client, bool value);
 
 /**
  * Set all weapon restrict array for all clients.
- * @param client    The client index.
  * @param value	   The restrict value
  * @noreturn        
  */
@@ -137,16 +136,16 @@ native void ZR_SetAllRestrictAll(bool value);
 /**
  * Set weapon restrict value to a specific client.
  * @param client    		 The client index.
- * @param returntarget    The weapon or weapon type name.
+ * @param weapon    The weapon or weapon type name.
  * @param value	   		 The restrict value
  * @return				 True on success, false otherwise            
  */
-native bool ZR_SetClientWeaponRestrict(int client, const char[] returntarget, bool value);
+native bool ZR_SetClientWeaponRestrict(int client, const char[] weapon, bool value);
 
 /**
  * Set weapon restrict value to all clients.
- * @param returntarget    The weapon or weapon type name.
+ * @param weapon    The weapon or weapon type name.
  * @param value	   		 The restrict value
  * @return				 True on success, false otherwise        
  */
-native bool ZR_SetAllWeaponRestrict(const char[] returntarget, bool value);
+native bool ZR_SetAllWeaponRestrict(const char[] weapon, bool value);

--- a/src/addons/sourcemod/scripting/include/zr/weapons.zr.inc
+++ b/src/addons/sourcemod/scripting/include/zr/weapons.zr.inc
@@ -120,32 +120,32 @@ native bool ZR_SetWeaponKnockback(const char[] weapon, float value);
 
 /**
  * Set all weapon restrict array for the specified client.
- * @param client    The client index.
- * @param value	   The restrict value
- * @noreturn        
+ * @param client        The client index.
+ * @param value         The restrict value
+ * @noreturn
  */
 native void ZR_SetClientWeaponRestrictAll(int client, bool value);
 
 /**
  * Set all weapon restrict array for all clients.
- * @param value	   The restrict value
- * @noreturn        
+ * @param value         The restrict value
+ * @noreturn
  */
 native void ZR_SetAllRestrictAll(bool value);
 
 /**
  * Set weapon restrict value to a specific client.
- * @param client    		 The client index.
- * @param weapon    The weapon or weapon type name.
- * @param value	   		 The restrict value
- * @return				 True on success, false otherwise            
+ * @param client        The client index.
+ * @param weapon        The weapon or weapon type name.
+ * @param value         The restrict value
+ * @return              True on success, false otherwise
  */
 native bool ZR_SetClientWeaponRestrict(int client, const char[] weapon, bool value);
 
 /**
  * Set weapon restrict value to all clients.
- * @param weapon    The weapon or weapon type name.
- * @param value	   		 The restrict value
- * @return				 True on success, false otherwise        
+ * @param weapon        The weapon or weapon type name.
+ * @param value         The restrict value
+ * @return              True on success, false otherwise
  */
 native bool ZR_SetAllWeaponRestrict(const char[] weapon, bool value);

--- a/src/addons/sourcemod/scripting/include/zr/weapons.zr.inc
+++ b/src/addons/sourcemod/scripting/include/zr/weapons.zr.inc
@@ -119,7 +119,7 @@ native bool ZR_GetWeaponZMarketCommand(const char[] weapon, char[] command, int 
 native bool ZR_SetWeaponKnockback(const char[] weapon, float value);
 
 /**
- * Set all wepaon restrict array for the specified client.
+ * Set all weapon restrict array for the specified client.
  * @param client    The client index.
  * @param value	   The restrict value
  * @noreturn        
@@ -127,7 +127,7 @@ native bool ZR_SetWeaponKnockback(const char[] weapon, float value);
 native void ZR_SetClientWeaponRestrictAll(int client, bool value);
 
 /**
- * Set all wepaon restrict array for all clients.
+ * Set all weapon restrict array for all clients.
  * @param client    The client index.
  * @param value	   The restrict value
  * @noreturn        

--- a/src/addons/sourcemod/scripting/zr/api/weapons.api.inc
+++ b/src/addons/sourcemod/scripting/zr/api/weapons.api.inc
@@ -227,7 +227,13 @@ void APIWeaponsInit()
     CreateNative("ZR_GetWeaponZMarketPurchaseMax", Native_GetWeaponZMarketPurchaseMax);
     CreateNative("ZR_GetWeaponZMarketCommand", Native_GetWeaponZMarketCommand);
     CreateNative("ZR_SetWeaponKnockback", Native_SetWeaponKnockback);
-
+	
+    // Restrict Natives
+    CreateNative("ZR_SetClientWeaponRestrictAll", Native_SetClientWeaponRestrictAll);
+    CreateNative("ZR_SetAllRestrictAll", Native_SetAllRestrictAll);
+    CreateNative("ZR_SetClientWeaponRestrict", Native_SetClientWeaponRestrict);
+    CreateNative("ZR_SetAllWeaponRestrict", Native_SetAllWeaponRestrict);
+	
     // Forwards
 }
 
@@ -456,6 +462,50 @@ public int Native_SetWeaponKnockback(Handle plugin, int numParams)
 
     KBQ_EnqueueOrUpdate(weapon, value);
     return true; // request accepted; application will occur asynchronously
+}
+
+public int Native_SetClientWeaponRestrictAll(Handle plugin, int numParams)
+{
+    int client = GetNativeCell(1);
+    
+    // Validate the client index.
+    APIValidateClientIndex(client);
+    
+    bool restrictvalue = view_as<bool>(GetNativeCell(2));
+    WeaponsSetClientWeaponRestrictAll(client, restrictvalue);
+    return 1;
+}
+
+public int Native_SetAllRestrictAll(Handle plugin, int numParams)
+{
+    bool restrictvalue = view_as<bool>(GetNativeCell(1));
+    WeaponsSetAllRestrictAll(restrictvalue);
+    return 1;
+}
+
+public int Native_SetClientWeaponRestrict(Handle plugin, int numParams)
+{
+    int client = GetNativeCell(1);
+    
+    // Validate the client index.
+    APIValidateClientIndex(client);
+    
+    char weapon[WEAPONS_MAX_LENGTH];
+    GetNativeString(2, weapon, sizeof(weapon));
+    
+    bool restrictvalue = view_as<bool>(GetNativeCell(3));
+    
+    return WeaponsSetClientWeaponRestrict(client, weapon, restrictvalue);
+}
+
+public int Native_SetAllWeaponRestrict(Handle plugin, int numParams)
+{
+    char weapon[WEAPONS_MAX_LENGTH];
+    GetNativeString(1, weapon, sizeof(weapon));
+    
+    bool restrictvalue = view_as<bool>(GetNativeCell(2));
+    
+    return WeaponsSetAllWeaponRestrict(weapon, restrictvalue);
 }
 
 /**

--- a/src/addons/sourcemod/scripting/zr/api/weapons.api.inc
+++ b/src/addons/sourcemod/scripting/zr/api/weapons.api.inc
@@ -227,7 +227,6 @@ void APIWeaponsInit()
     CreateNative("ZR_GetWeaponZMarketPurchaseMax", Native_GetWeaponZMarketPurchaseMax);
     CreateNative("ZR_GetWeaponZMarketCommand", Native_GetWeaponZMarketCommand);
     CreateNative("ZR_SetWeaponKnockback", Native_SetWeaponKnockback);
-	
     // Restrict Natives
     CreateNative("ZR_SetClientWeaponRestrictAll", Native_SetClientWeaponRestrictAll);
     CreateNative("ZR_SetAllRestrictAll", Native_SetAllRestrictAll);
@@ -466,6 +465,9 @@ public int Native_SetWeaponKnockback(Handle plugin, int numParams)
 
 public int Native_SetClientWeaponRestrictAll(Handle plugin, int numParams)
 {
+    if (!g_hCvarsList.CVAR_WEAPONS_RESTRICT_PERPLAYER.BoolValue)
+        return ThrowNativeError(SP_ERROR_NATIVE, "Per-player restriction is disabled.");
+
     int client = GetNativeCell(1);
     
     // Validate the client index.
@@ -478,6 +480,9 @@ public int Native_SetClientWeaponRestrictAll(Handle plugin, int numParams)
 
 public int Native_SetAllRestrictAll(Handle plugin, int numParams)
 {
+    if (!g_hCvarsList.CVAR_WEAPONS_RESTRICT_PERPLAYER.BoolValue)
+        return ThrowNativeError(SP_ERROR_NATIVE, "Per-player restriction is disabled.");
+
     bool restrictvalue = view_as<bool>(GetNativeCell(1));
     WeaponsSetAllRestrictAll(restrictvalue);
     return 1;
@@ -485,6 +490,9 @@ public int Native_SetAllRestrictAll(Handle plugin, int numParams)
 
 public int Native_SetClientWeaponRestrict(Handle plugin, int numParams)
 {
+    if (!g_hCvarsList.CVAR_WEAPONS_RESTRICT_PERPLAYER.BoolValue)
+        return ThrowNativeError(SP_ERROR_NATIVE, "Per-player restriction is disabled.");
+
     int client = GetNativeCell(1);
     
     // Validate the client index.
@@ -500,6 +508,9 @@ public int Native_SetClientWeaponRestrict(Handle plugin, int numParams)
 
 public int Native_SetAllWeaponRestrict(Handle plugin, int numParams)
 {
+    if (!g_hCvarsList.CVAR_WEAPONS_RESTRICT_PERPLAYER.BoolValue)
+        return ThrowNativeError(SP_ERROR_NATIVE, "Per-player restriction is disabled.");
+
     char weapon[WEAPONS_MAX_LENGTH];
     GetNativeString(1, weapon, sizeof(weapon));
     

--- a/src/addons/sourcemod/scripting/zr/api/weapons.api.inc
+++ b/src/addons/sourcemod/scripting/zr/api/weapons.api.inc
@@ -465,7 +465,7 @@ public int Native_SetWeaponKnockback(Handle plugin, int numParams)
 
 public int Native_SetClientWeaponRestrictAll(Handle plugin, int numParams)
 {
-    if (!g_hCvarsList.CVAR_WEAPONS_RESTRICT_PERPLAYER.BoolValue)
+    if (!g_hCvarsList.CVAR_WEAPONS_RESTRICT_PERPLAYER.BoolValue || !g_hCvarsList.CVAR_WEAPONS_RESTRICT.BoolValue)
         return ThrowNativeError(SP_ERROR_NATIVE, "Per-player restriction is disabled.");
 
     int client = GetNativeCell(1);
@@ -480,7 +480,7 @@ public int Native_SetClientWeaponRestrictAll(Handle plugin, int numParams)
 
 public int Native_SetAllRestrictAll(Handle plugin, int numParams)
 {
-    if (!g_hCvarsList.CVAR_WEAPONS_RESTRICT_PERPLAYER.BoolValue)
+    if (!g_hCvarsList.CVAR_WEAPONS_RESTRICT_PERPLAYER.BoolValue || !g_hCvarsList.CVAR_WEAPONS_RESTRICT.BoolValue)
         return ThrowNativeError(SP_ERROR_NATIVE, "Per-player restriction is disabled.");
 
     bool restrictvalue = view_as<bool>(GetNativeCell(1));
@@ -490,7 +490,7 @@ public int Native_SetAllRestrictAll(Handle plugin, int numParams)
 
 public int Native_SetClientWeaponRestrict(Handle plugin, int numParams)
 {
-    if (!g_hCvarsList.CVAR_WEAPONS_RESTRICT_PERPLAYER.BoolValue)
+    if (!g_hCvarsList.CVAR_WEAPONS_RESTRICT_PERPLAYER.BoolValue || !g_hCvarsList.CVAR_WEAPONS_RESTRICT.BoolValue)
         return ThrowNativeError(SP_ERROR_NATIVE, "Per-player restriction is disabled.");
 
     int client = GetNativeCell(1);
@@ -508,7 +508,7 @@ public int Native_SetClientWeaponRestrict(Handle plugin, int numParams)
 
 public int Native_SetAllWeaponRestrict(Handle plugin, int numParams)
 {
-    if (!g_hCvarsList.CVAR_WEAPONS_RESTRICT_PERPLAYER.BoolValue)
+    if (!g_hCvarsList.CVAR_WEAPONS_RESTRICT_PERPLAYER.BoolValue || !g_hCvarsList.CVAR_WEAPONS_RESTRICT.BoolValue)
         return ThrowNativeError(SP_ERROR_NATIVE, "Per-player restriction is disabled.");
 
     char weapon[WEAPONS_MAX_LENGTH];

--- a/src/addons/sourcemod/scripting/zr/api/weapons.api.inc
+++ b/src/addons/sourcemod/scripting/zr/api/weapons.api.inc
@@ -232,7 +232,7 @@ void APIWeaponsInit()
     CreateNative("ZR_SetAllRestrictAll", Native_SetAllRestrictAll);
     CreateNative("ZR_SetClientWeaponRestrict", Native_SetClientWeaponRestrict);
     CreateNative("ZR_SetAllWeaponRestrict", Native_SetAllWeaponRestrict);
-	
+
     // Forwards
 }
 
@@ -240,16 +240,16 @@ public int Native_GetWeaponEntity(Handle plugin, int numParams)
 {
     char weapon[WEAPONS_MAX_LENGTH];
     GetNativeString(1, weapon, sizeof(weapon));
-    
+
     int index = WeaponsNameToIndex(weapon);
     if (index == -1)
     {
         return false;
     }
-    
+
     char entity[WEAPONS_MAX_LENGTH];
     WeaponsGetEntity(index, entity, sizeof(entity));
-    
+
     SetNativeString(2, entity, GetNativeCell(3));
     return true;
 }
@@ -258,16 +258,16 @@ public int Native_GetWeaponType(Handle plugin, int numParams)
 {
     char weapon[WEAPONS_MAX_LENGTH];
     GetNativeString(1, weapon, sizeof(weapon));
-    
+
     int index = WeaponsNameToIndex(weapon);
     if (index == -1)
     {
         return false;
     }
-    
+
     char type[WEAPONS_MAX_LENGTH];
     WeaponsGetType(index, type, sizeof(type));
-    
+
     SetNativeString(2, type, GetNativeCell(3));
     return true;
 }
@@ -276,13 +276,13 @@ public int Native_GetWeaponSlot(Handle plugin, int numParams)
 {
     char weapon[WEAPONS_MAX_LENGTH];
     GetNativeString(1, weapon, sizeof(weapon));
-    
+
     int index = WeaponsNameToIndex(weapon);
     if (index == -1)
     {
         return -1;
     }
-    
+
     return view_as<int>(WeaponsGetSlot(index));
 }
 
@@ -290,13 +290,13 @@ public int Native_GetWeaponRestrictDefault(Handle plugin, int numParams)
 {
     char weapon[WEAPONS_MAX_LENGTH];
     GetNativeString(1, weapon, sizeof(weapon));
-    
+
     int index = WeaponsNameToIndex(weapon);
     if (index == -1)
     {
         return false;
     }
-    
+
     return WeaponsGetRestrictDefault(index);
 }
 
@@ -304,13 +304,13 @@ public int Native_GetWeaponToggleable(Handle plugin, int numParams)
 {
     char weapon[WEAPONS_MAX_LENGTH];
     GetNativeString(1, weapon, sizeof(weapon));
-    
+
     int index = WeaponsNameToIndex(weapon);
     if (index == -1)
     {
         return false;
     }
-    
+
     return WeaponsGetToggleable(index);
 }
 
@@ -318,16 +318,16 @@ public int Native_GetWeaponAmmoType(Handle plugin, int numParams)
 {
     char weapon[WEAPONS_MAX_LENGTH];
     GetNativeString(1, weapon, sizeof(weapon));
-    
+
     int index = WeaponsNameToIndex(weapon);
     if (index == -1)
     {
         return false;
     }
-    
+
     char ammotype[WEAPONS_MAX_LENGTH];
     WeaponsGetAmmoType(index, ammotype, sizeof(ammotype));
-    
+
     SetNativeString(2, ammotype, GetNativeCell(3));
     return true;
 }
@@ -336,13 +336,13 @@ public int Native_GetWeaponAmmoPrice(Handle plugin, int numParams)
 {
     char weapon[WEAPONS_MAX_LENGTH];
     GetNativeString(1, weapon, sizeof(weapon));
-    
+
     int index = WeaponsNameToIndex(weapon);
     if (index == -1)
     {
         return -1;
     }
-    
+
     return WeaponsGetAmmoPrice(index);
 }
 
@@ -350,13 +350,13 @@ public int Native_GetWeaponKnockback(Handle plugin, int numParams)
 {
     char weapon[WEAPONS_MAX_LENGTH];
     GetNativeString(1, weapon, sizeof(weapon));
-    
+
     int index = WeaponsNameToIndex(weapon);
     if (index == -1)
     {
         return view_as<int>(0.0);
     }
-    
+
     return view_as<int>(WeaponsGetKnockback(index));
 }
 
@@ -364,16 +364,16 @@ public int Native_GetWeaponZMarketName(Handle plugin, int numParams)
 {
     char weapon[WEAPONS_MAX_LENGTH];
     GetNativeString(1, weapon, sizeof(weapon));
-    
+
     int index = WeaponsNameToIndex(weapon);
     if (index == -1)
     {
         return false;
     }
-    
+
     char name[WEAPONS_MAX_LENGTH];
     WeaponsGetZMarketName(index, name, sizeof(name));
-    
+
     SetNativeString(2, name, GetNativeCell(3));
     return true;
 }
@@ -382,13 +382,13 @@ public int Native_GetWeaponZMarketPrice(Handle plugin, int numParams)
 {
     char weapon[WEAPONS_MAX_LENGTH];
     GetNativeString(1, weapon, sizeof(weapon));
-    
+
     int index = WeaponsNameToIndex(weapon);
     if (index == -1)
     {
         return -1;
     }
-    
+
     return WeaponsGetZMarketPrice(index);
 }
 
@@ -396,13 +396,13 @@ public int Native_GetWeaponZMarketPurchaseMax(Handle plugin, int numParams)
 {
     char weapon[WEAPONS_MAX_LENGTH];
     GetNativeString(1, weapon, sizeof(weapon));
-    
+
     int index = WeaponsNameToIndex(weapon);
     if (index == -1)
     {
         return -1;
     }
-    
+
     return WeaponsGetZMarketPurchaseMax(index);
 }
 
@@ -410,16 +410,16 @@ public int Native_GetWeaponZMarketCommand(Handle plugin, int numParams)
 {
     char weapon[WEAPONS_MAX_LENGTH];
     GetNativeString(1, weapon, sizeof(weapon));
-    
+
     int index = WeaponsNameToIndex(weapon);
     if (index == -1)
     {
         return false;
     }
-    
+
     char command[WEAPONS_MAX_LENGTH];
     WeaponsGetZMarketCommand(index, command, sizeof(command));
-    
+
     SetNativeString(2, command, GetNativeCell(3));
     return true;
 }
@@ -446,7 +446,7 @@ public int Native_SetWeaponKnockback(Handle plugin, int numParams)
     {
         return false;
     }
-    
+
     float value = GetNativeCell(2);
     if (value <= 0.0)
     {
@@ -469,10 +469,10 @@ public int Native_SetClientWeaponRestrictAll(Handle plugin, int numParams)
         return ThrowNativeError(SP_ERROR_NATIVE, "Per-player restriction is disabled.");
 
     int client = GetNativeCell(1);
-    
+
     // Validate the client index.
     APIValidateClientIndex(client);
-    
+
     bool restrictvalue = view_as<bool>(GetNativeCell(2));
     WeaponsSetClientWeaponRestrictAll(client, restrictvalue);
     return 1;
@@ -494,15 +494,15 @@ public int Native_SetClientWeaponRestrict(Handle plugin, int numParams)
         return ThrowNativeError(SP_ERROR_NATIVE, "Per-player restriction is disabled.");
 
     int client = GetNativeCell(1);
-    
+
     // Validate the client index.
     APIValidateClientIndex(client);
-    
+
     char weapon[WEAPONS_MAX_LENGTH];
     GetNativeString(2, weapon, sizeof(weapon));
-    
+
     bool restrictvalue = view_as<bool>(GetNativeCell(3));
-    
+
     return WeaponsSetClientWeaponRestrict(client, weapon, restrictvalue);
 }
 
@@ -513,12 +513,12 @@ public int Native_SetAllWeaponRestrict(Handle plugin, int numParams)
 
     char weapon[WEAPONS_MAX_LENGTH];
     GetNativeString(1, weapon, sizeof(weapon));
-    
+
     bool restrictvalue = view_as<bool>(GetNativeCell(2));
-    
+
     return WeaponsSetAllWeaponRestrict(weapon, restrictvalue);
 }
 
 /**
  * @endsection
- */ 
+ */

--- a/src/addons/sourcemod/scripting/zr/cvars.inc
+++ b/src/addons/sourcemod/scripting/zr/cvars.inc
@@ -74,6 +74,7 @@ enum struct CvarsList
     ConVar CVAR_CLASSES_SPEED_METHOD;
     ConVar CVAR_WEAPONS;
     ConVar CVAR_WEAPONS_RESTRICT;
+    ConVar CVAR_WEAPONS_RESTRICT_PERPLAYER;
     ConVar CVAR_WEAPONS_RESTRICT_ENDEQUIP;
     ConVar CVAR_WEAPONS_ZMARKET;
     ConVar CVAR_WEAPONS_ZMARKET_BUYZONE;
@@ -298,6 +299,7 @@ void CvarsCreate()
 
     // Restrict
     g_hCvarsList.CVAR_WEAPONS_RESTRICT                 =    CreateConVar("zr_weapons_restrict",            "1",    "Enable weapon restriction module, disabling this will disable weapon restriction commands.");
+    g_hCvarsList.CVAR_WEAPONS_RESTRICT_PERPLAYER       =    CreateConVar("zr_weapons_restrict_perplayer",  "1",    "Enable weapon restriction per-player module. [Dependency: zr_weapons_restrict]");
     g_hCvarsList.CVAR_WEAPONS_RESTRICT_ENDEQUIP        =    CreateConVar("zr_weapons_restrict_endequip",   "1",    "Restricts zombies from picking up weapons after the round has ended but before the next round has begun.");
 
     // ZMarket

--- a/src/addons/sourcemod/scripting/zr/cvars.inc
+++ b/src/addons/sourcemod/scripting/zr/cvars.inc
@@ -299,7 +299,7 @@ void CvarsCreate()
 
     // Restrict
     g_hCvarsList.CVAR_WEAPONS_RESTRICT                 =    CreateConVar("zr_weapons_restrict",            "1",    "Enable weapon restriction module, disabling this will disable weapon restriction commands.");
-    g_hCvarsList.CVAR_WEAPONS_RESTRICT_PERPLAYER       =    CreateConVar("zr_weapons_restrict_perplayer",  "1",    "Enable weapon restriction per-player module. [Dependency: zr_weapons_restrict]");
+    g_hCvarsList.CVAR_WEAPONS_RESTRICT_PERPLAYER       =    CreateConVar("zr_weapons_restrict_perplayer",  "0",    "Enable weapon restriction per-player module. [Dependency: zr_weapons_restrict]");
     g_hCvarsList.CVAR_WEAPONS_RESTRICT_ENDEQUIP        =    CreateConVar("zr_weapons_restrict_endequip",   "1",    "Restricts zombies from picking up weapons after the round has ended but before the next round has begun.");
 
     // ZMarket

--- a/src/addons/sourcemod/scripting/zr/hgversion.h.inc
+++ b/src/addons/sourcemod/scripting/zr/hgversion.h.inc
@@ -4,7 +4,7 @@
 #define ZR_VER_BRANCH           "master"
 #define ZR_VER_MAJOR            "3"
 #define ZR_VER_MINOR            "12"
-#define ZR_VER_PATCH            "26"
+#define ZR_VER_PATCH            "27"
 #define ZR_VERSION              ZR_VER_MAJOR..."."...ZR_VER_MINOR..."."...ZR_VER_PATCH
 #define ZR_VER_LICENSE          "GNU GPL, Version 3"
 #define ZR_VER_DATE             "Thu Dec 04 14:52:00 CET 2025"

--- a/src/addons/sourcemod/scripting/zr/weapons/menu_weapons.inc
+++ b/src/addons/sourcemod/scripting/zr/weapons/menu_weapons.inc
@@ -392,7 +392,7 @@ void WeaponsMenuPerPlayerRestrict(int client)
 
     menu_weapons_perplayerrestrict.SetTitle(title);
 
-	char display[MENU_LINE_SMALL_LENGTH]
+	char display[MENU_LINE_SMALL_LENGTH];
 
 	// x = Client index
 	for (int x = 1; x <= MaxClients; x++)

--- a/src/addons/sourcemod/scripting/zr/weapons/menu_weapons.inc
+++ b/src/addons/sourcemod/scripting/zr/weapons/menu_weapons.inc
@@ -106,9 +106,9 @@ public int WeaponsMenuMainHandle(Menu menu_weapons_main, MenuAction action, int 
             }
             case 2:
             {
-            	// Per-Player restrict system, a menu will pop up
-            	WeaponsMenuPerPlayerRestrict(client);
-            	return 0;
+                // Per-Player restrict system, a menu will pop up
+                WeaponsMenuPerPlayerRestrict(client);
+                return 0;
             }
         }
     }

--- a/src/addons/sourcemod/scripting/zr/weapons/menu_weapons.inc
+++ b/src/addons/sourcemod/scripting/zr/weapons/menu_weapons.inc
@@ -66,9 +66,13 @@ bool WeaponsMenuMain(int client)
 
     // Draw items, make unselectable if module is disabled.
     menu_weapons_main.SetTitle(title);
-    menu_weapons_main.AddItem("restrict", restrict, MenuGetItemDraw(g_hCvarsList.CVAR_WEAPONS_RESTRICT.BoolValue));
+
+    bool restrictenabled = g_hCvarsList.CVAR_WEAPONS_RESTRICT.BoolValue;
+    menu_weapons_main.AddItem("restrict", restrict, MenuGetItemDraw(restrictenabled));
     menu_weapons_main.AddItem("zmarket", zmarket, MenuGetItemDraw(g_hCvarsList.CVAR_WEAPONS_ZMARKET.BoolValue));
-    menu_weapons_main.AddItem("perplayerestrict", perplayerestrict, MenuGetItemDraw(g_hCvarsList.CVAR_WEAPONS_RESTRICT.BoolValue && g_hCvarsList.CVAR_WEAPONS_RESTRICT_PERPLAYER.BoolValue));
+
+    bool perplayerestrictenabled = restrictenabled && g_hCvarsList.CVAR_WEAPONS_RESTRICT_PERPLAYER.BoolValue && ZRIsClientPrivileged(client, OperationType_Generic);
+    menu_weapons_main.AddItem("perplayerestrict", perplayerestrict, MenuGetItemDraw(perplayerestrictenabled));
 
     // Create a "Back" button to the weapons main menu.
     menu_weapons_main.ExitBackButton = true;

--- a/src/addons/sourcemod/scripting/zr/weapons/menu_weapons.inc
+++ b/src/addons/sourcemod/scripting/zr/weapons/menu_weapons.inc
@@ -419,10 +419,10 @@ void WeaponsMenuPerPlayerRestrict(int client)
 /**
  * Called when client selects an item in per-player restrictions menu.
  *
- * @param menu_weapons_perplayerrestrict  	Handle of the menu being used.
- * @param action                    		The action done on the menu (see menus.inc, enum MenuAction).
- * @param client                    		The client index.
- * @param slot                      		The slot index selected (starting from 0).
+ * @param menu_weapons_perplayerrestrict    Handle of the menu being used.
+ * @param action                            The action done on the menu (see menus.inc, enum MenuAction).
+ * @param client                            The client index.
+ * @param slot                              The slot index selected (starting from 0).
  */
 public int WeaponsMenuPerPlayerRestrictHandle(Menu menu_weapons_perplayerrestrict, MenuAction action, int client, int slot)
 {
@@ -520,10 +520,10 @@ void WeaponsMenuWeaponsTypesTarget(int client, int target = 0)
 /**
  * Called when client selects an item in per-player weapons types restriction.
  *
- * @param menu_weapon_types_target  		Handle of the menu being used.
- * @param action                    		The action done on the menu (see menus.inc, enum MenuAction).
- * @param client                    		The client index.
- * @param slot                      		The slot index selected (starting from 0).
+ * @param menu_weapon_types_target          Handle of the menu being used.
+ * @param action                            The action done on the menu (see menus.inc, enum MenuAction).
+ * @param client                            The client index.
+ * @param slot                              The slot index selected (starting from 0).
  */
 public int WeaponsMenuWeaponsTypesTargetHandle(Menu menu_weapon_types_target, MenuAction action, int client, int slot)
 {
@@ -629,10 +629,10 @@ void WeaponsMenuWeaponsTypeTarget(int client, int target = 0)
 /**
  * Called when client selects option in the per-player weapon group menu, and handles it.
  *
- * @param menu_weapons_type_target  	Handle of the menu being used.
- * @param action                    	The action done on the menu (see menus.inc, enum MenuAction).
- * @param client                    	The client index.
- * @param slot                      	The slot index selected (starting from 0).
+ * @param menu_weapons_type_target      Handle of the menu being used.
+ * @param action                        The action done on the menu (see menus.inc, enum MenuAction).
+ * @param client                        The client index.
+ * @param slot                          The slot index selected (starting from 0).
  */
 public int WeaponsMenuWeaponsTypeTargetHandle(Menu menu_weapons_type_target, MenuAction action, int client, int slot)
 {

--- a/src/addons/sourcemod/scripting/zr/weapons/menu_weapons.inc
+++ b/src/addons/sourcemod/scripting/zr/weapons/menu_weapons.inc
@@ -63,7 +63,7 @@ bool WeaponsMenuMain(int client)
     Format(restrict, sizeof(restrict), "%t", "Weapons menu restrict main restrict");
     Format(zmarket, sizeof(zmarket), "%t", "Weapons menu restrict main market");
     Format(perplayerestrict, sizeof(perplayerestrict), "%t", "Weapons menu restrict per player");
-	
+
     // Draw items, make unselectable if module is disabled.
     menu_weapons_main.SetTitle(title);
     menu_weapons_main.AddItem("restrict", restrict, MenuGetItemDraw(g_hCvarsList.CVAR_WEAPONS_RESTRICT.BoolValue));
@@ -392,22 +392,22 @@ void WeaponsMenuPerPlayerRestrict(int client)
 
     menu_weapons_perplayerrestrict.SetTitle(title);
 
-	char display[MENU_LINE_SMALL_LENGTH];
+    char display[MENU_LINE_SMALL_LENGTH];
 
-	// x = Client index
-	for (int x = 1; x <= MaxClients; x++)
-	{
-		if (!IsClientInGame(x) || IsFakeClient(x))
-			continue;
-		
-		int userid = GetClientUserId(x);
-		
-		char useridStr[8];
-		IntToString(userid, useridStr, sizeof(useridStr));
-		
-		FormatEx(display, sizeof(display), "[#%d] %N", userid, x);
-		menu_weapons_perplayerrestrict.AddItem(useridStr, display);
-	}
+    // x = Client index
+    for (int x = 1; x <= MaxClients; x++)
+    {
+        if (!IsClientInGame(x) || IsFakeClient(x))
+            continue;
+
+        int userid = GetClientUserId(x);
+
+        char useridStr[8];
+        IntToString(userid, useridStr, sizeof(useridStr));
+
+        FormatEx(display, sizeof(display), "[#%d] %N", userid, x);
+        menu_weapons_perplayerrestrict.AddItem(useridStr, display);
+    }
 
     // Set menu back button.
     menu_weapons_perplayerrestrict.ExitBackButton = true;
@@ -432,17 +432,17 @@ public int WeaponsMenuPerPlayerRestrictHandle(Menu menu_weapons_perplayerrestric
         // Get the userid of the player selected
         char data[10];
         menu_weapons_perplayerrestrict.GetItem(slot, data, sizeof(data));
-        
+
         int userid = StringToInt(data);
 
         int target = GetClientOfUserId(userid);
         if (!target)
         {
-       		WeaponsMenuPerPlayerRestrict(client);
-       		return 0;
-      	}
+            WeaponsMenuPerPlayerRestrict(client);
+            return 0;
+        }
 
-		g_iWeaponsCurTarget[client] = userid;
+        g_iWeaponsCurTarget[client] = userid;
         WeaponsMenuWeaponsTypesTarget(client, target);
         return 0;
     }
@@ -470,18 +470,18 @@ public int WeaponsMenuPerPlayerRestrictHandle(Menu menu_weapons_perplayerrestric
  */
 void WeaponsMenuWeaponsTypesTarget(int client, int target = 0)
 {
-	// Get target index from userid.
-	if (!target)
-		target = GetClientOfUserId(g_iWeaponsCurTarget[client]);
-	
-	// If the target is not available anymore, then stop.
-	if (!target)
-		return;
+    // Get target index from userid.
+    if (!target)
+        target = GetClientOfUserId(g_iWeaponsCurTarget[client]);
 
-	// Create menu handle.
+    // If the target is not available anymore, then stop.
+    if (!target)
+        return;
+
+    // Create menu handle.
     Menu menu_weapon_types_target = new Menu(WeaponsMenuWeaponsTypesTargetHandle);
 
-   	SetGlobalTransTarget(client);
+    SetGlobalTransTarget(client);
 
     char title[MENU_LINE_TITLE_LENGTH];
     Format(title, sizeof(title), "%t\n ", "Weapons menu restrict types per-player title", target);
@@ -560,15 +560,15 @@ public int WeaponsMenuWeaponsTypesTargetHandle(Menu menu_weapon_types_target, Me
  */
 void WeaponsMenuWeaponsTypeTarget(int client, int target = 0)
 {
-	// Get target index from userid.
-	if (!target)
-		target = GetClientOfUserId(g_iWeaponsCurTarget[client]);
-	
-	// If the target is not available anymore, then stop.
-	if (!target)
-		return;
+    // Get target index from userid.
+    if (!target)
+        target = GetClientOfUserId(g_iWeaponsCurTarget[client]);
 
-	// Create menu handle.
+    // If the target is not available anymore, then stop.
+    if (!target)
+        return;
+
+    // Create menu handle.
     Menu menu_weapons_type_target = new Menu(WeaponsMenuWeaponsTypeTargetHandle);
 
     char typename[WEAPONS_MAX_LENGTH];
@@ -639,15 +639,15 @@ public int WeaponsMenuWeaponsTypeTargetHandle(Menu menu_weapons_type_target, Men
     // Client selected an option.
     if (action == MenuAction_Select)
     {
-    	// Get the target index.
-    	int target = GetClientOfUserId(g_iWeaponsCurTarget[client]);
-    	
-    	// If target is not available anymore, then stop.
-    	if (!target)
-    	{
-    		WeaponsMenuPerPlayerRestrict(client);
-    		return 0;
-   		}
+        // Get the target index.
+        int target = GetClientOfUserId(g_iWeaponsCurTarget[client]);
+
+        // If target is not available anymore, then stop.
+        if (!target)
+        {
+            WeaponsMenuPerPlayerRestrict(client);
+            return 0;
+        }
 
         // Get name of current weapon type.
         char typename[WEAPONS_MAX_LENGTH];
@@ -690,7 +690,7 @@ public int WeaponsMenuWeaponsTypeTargetHandle(Menu menu_weapons_type_target, Men
                     delete menu_weapons_type_target;
                     return -1;
                 }
-				
+
                 // If weapon isn't restricted, then restrict it.
                 if (!RestrictIsClientWeaponRestrict(target, weaponindex))
                 {
@@ -724,11 +724,11 @@ public int WeaponsMenuWeaponsTypeTargetHandle(Menu menu_weapons_type_target, Men
         // Client hit "Back" button.
         if (slot == MenuCancel_ExitBack)
         {
-        	int target = GetClientOfUserId(g_iWeaponsCurTarget[client]);
-        	if (target)
-        		WeaponsMenuWeaponsTypesTarget(client, target);
-        	else
-            	WeaponsMenuPerPlayerRestrict(client);
+            int target = GetClientOfUserId(g_iWeaponsCurTarget[client]);
+            if (target)
+                WeaponsMenuWeaponsTypesTarget(client, target);
+            else
+                WeaponsMenuPerPlayerRestrict(client);
         }
     }
     // Client hit "Exit" button.

--- a/src/addons/sourcemod/scripting/zr/weapons/menu_weapons.inc
+++ b/src/addons/sourcemod/scripting/zr/weapons/menu_weapons.inc
@@ -31,6 +31,11 @@
 int g_iWeaponsCurType[MAXPLAYERS + 1];
 
 /**
+ * Array to store the client's current target's userid within menu.
+ */
+int g_iWeaponsCurTarget[MAXPLAYERS + 1];
+
+/**
  * Sends main weapon menu to client.
  *
  * @param client    The client index.
@@ -52,15 +57,18 @@ bool WeaponsMenuMain(int client)
     char title[MENU_LINE_TITLE_LENGTH];
     char restrict[MENU_LINE_SMALL_LENGTH];
     char zmarket[MENU_LINE_SMALL_LENGTH];
+    char perplayerestrict[MENU_LINE_SMALL_LENGTH];
 
     Format(title, sizeof(title), "%t\n ", "Weapons menu restrict main title");
     Format(restrict, sizeof(restrict), "%t", "Weapons menu restrict main restrict");
     Format(zmarket, sizeof(zmarket), "%t", "Weapons menu restrict main market");
-
+    Format(perplayerestrict, sizeof(perplayerestrict), "%t", "Weapons menu restrict per player");
+	
     // Draw items, make unselectable if module is disabled.
     menu_weapons_main.SetTitle(title);
     menu_weapons_main.AddItem("restrict", restrict, MenuGetItemDraw(g_hCvarsList.CVAR_WEAPONS_RESTRICT.BoolValue));
     menu_weapons_main.AddItem("zmarket", zmarket, MenuGetItemDraw(g_hCvarsList.CVAR_WEAPONS_ZMARKET.BoolValue));
+    menu_weapons_main.AddItem("perplayerestrict", perplayerestrict, MenuGetItemDraw(g_hCvarsList.CVAR_WEAPONS_RESTRICT.BoolValue && g_hCvarsList.CVAR_WEAPONS_RESTRICT_PERPLAYER.BoolValue));
 
     // Create a "Back" button to the weapons main menu.
     menu_weapons_main.ExitBackButton = true;
@@ -95,6 +103,12 @@ public int WeaponsMenuMainHandle(Menu menu_weapons_main, MenuAction action, int 
             case 1:
             {
                 WeaponsMenuZMarket(client);
+            }
+            case 2:
+            {
+            	// Per-Player restrict system, a menu will pop up
+            	WeaponsMenuPerPlayerRestrict(client);
+            	return 0;
             }
         }
     }
@@ -354,6 +368,373 @@ public int WeaponsMenuTypeWeaponsHandle(Menu menu_weapons_typeweapons, MenuActio
     else if (action == MenuAction_End)
     {
         delete menu_weapons_typeweapons;
+    }
+    return -1;
+}
+
+/**
+ * Sends the list of online players to manage per-player weapon restrictions for a specific weapon type.
+ *
+ * @param client    The client index.
+ */
+
+void WeaponsMenuPerPlayerRestrict(int client)
+{
+    // Create menu handle.
+    Menu menu_weapons_perplayerrestrict = new Menu(WeaponsMenuPerPlayerRestrictHandle);
+
+    // Set translation language.
+    SetGlobalTransTarget(client);
+
+    char title[MENU_LINE_TITLE_LENGTH];
+
+    Format(title, sizeof(title), "%t\n ", "Weapons menu restrict per player title");
+
+    menu_weapons_perplayerrestrict.SetTitle(title);
+
+	char display[MENU_LINE_SMALL_LENGTH]
+
+	// x = Client index
+	for (int x = 1; x <= MaxClients; x++)
+	{
+		if (!IsClientInGame(x) || IsFakeClient(x))
+			continue;
+		
+		int userid = GetClientUserId(x);
+		
+		char useridStr[8];
+		IntToString(userid, useridStr, sizeof(useridStr));
+		
+		FormatEx(display, sizeof(display), "[#%d] %N", userid, x);
+		menu_weapons_perplayerrestrict.AddItem(useridStr, display);
+	}
+
+    // Set menu back button.
+    menu_weapons_perplayerrestrict.ExitBackButton = true;
+
+    // Display menu to client.
+    menu_weapons_perplayerrestrict.Display(client, MENU_TIME_FOREVER);
+}
+
+/**
+ * Called when client selects an item in per-player restrictions menu.
+ *
+ * @param menu_weapons_perplayerrestrict  	Handle of the menu being used.
+ * @param action                    		The action done on the menu (see menus.inc, enum MenuAction).
+ * @param client                    		The client index.
+ * @param slot                      		The slot index selected (starting from 0).
+ */
+public int WeaponsMenuPerPlayerRestrictHandle(Menu menu_weapons_perplayerrestrict, MenuAction action, int client, int slot)
+{
+    // Client selected an option.
+    if (action == MenuAction_Select)
+    {
+        // Get the userid of the player selected
+        char data[10];
+        menu_weapons_perplayerrestrict.GetItem(slot, data, sizeof(data));
+        
+        int userid = StringToInt(data);
+
+        int target = GetClientOfUserId(userid);
+        if (!target)
+        {
+       		WeaponsMenuPerPlayerRestrict(client);
+       		return 0;
+      	}
+
+		g_iWeaponsCurTarget[client] = userid;
+        WeaponsMenuWeaponsTypesTarget(client, target);
+        return 0;
+    }
+    // Client closed the menu.
+    if (action == MenuAction_Cancel)
+    {
+        // Client hit "Back" button.
+        if (slot == MenuCancel_ExitBack)
+        {
+            WeaponsMenuMain(client);
+        }
+    }
+    // Client hit "Exit" button.
+    else if (action == MenuAction_End)
+    {
+        delete menu_weapons_perplayerrestrict;
+    }
+    return -1;
+}
+
+/**
+ * Sends the list of weapons types to manage the selected player's restrictions.
+ *
+ * @param client    The client index.
+ */
+void WeaponsMenuWeaponsTypesTarget(int client, int target = 0)
+{
+	// Get target index from userid.
+	if (!target)
+		target = GetClientOfUserId(g_iWeaponsCurTarget[client]);
+	
+	// If the target is not available anymore, then stop.
+	if (!target)
+		return;
+
+	// Create menu handle.
+    Menu menu_weapon_types_target = new Menu(WeaponsMenuWeaponsTypesTargetHandle);
+
+   	SetGlobalTransTarget(client);
+
+    char title[MENU_LINE_TITLE_LENGTH];
+    Format(title, sizeof(title), "%t\n ", "Weapons menu restrict types per-player title", target);
+    menu_weapon_types_target.SetTitle(title);
+
+    char typename[WEAPONS_MAX_LENGTH];
+
+    // x = Array index.
+    int size = arrayWeaponTypes.Length;
+    for (int x = 0; x < size; x++)
+    {
+        // Get name of type.
+        RestrictWeaponTypeGetName(x, typename, sizeof(typename));
+
+        // Add item to menu.
+        menu_weapon_types_target.AddItem(typename, typename);
+    }
+
+    // If there are no weapons, add an "(Empty)" line.
+    if (size == 0)
+    {
+        SetGlobalTransTarget(client);
+
+        char empty[MENU_LINE_SMALL_LENGTH];
+        Format(empty, sizeof(empty), "%t", "Menu empty");
+
+        menu_weapon_types_target.AddItem("empty", empty, ITEMDRAW_DISABLED);
+    }
+
+    // Set exit back button.
+    menu_weapon_types_target.ExitBackButton = true;
+
+    menu_weapon_types_target.Display(client, MENU_TIME_FOREVER);
+}
+
+/**
+ * Called when client selects an item in per-player weapons types restriction.
+ *
+ * @param menu_weapon_types_target  		Handle of the menu being used.
+ * @param action                    		The action done on the menu (see menus.inc, enum MenuAction).
+ * @param client                    		The client index.
+ * @param slot                      		The slot index selected (starting from 0).
+ */
+public int WeaponsMenuWeaponsTypesTargetHandle(Menu menu_weapon_types_target, MenuAction action, int client, int slot)
+{
+    // Client selected an option.
+    if (action == MenuAction_Select)
+    {
+        // Menu slot index is = weapon type index.
+        g_iWeaponsCurType[client] = slot;
+
+        // Send weapons of the selected type in a menu to client.
+        WeaponsMenuWeaponsTypeTarget(client);
+    }
+    // Client closed the menu.
+    if (action == MenuAction_Cancel)
+    {
+        // Client hit "Back" button.
+        if (slot == MenuCancel_ExitBack)
+        {
+            WeaponsMenuPerPlayerRestrict(client);
+        }
+    }
+    // Client hit "Exit" button.
+    else if (action == MenuAction_End)
+    {
+        delete menu_weapon_types_target;
+    }
+    return -1;
+}
+
+/**
+ * Sends the the specified weapon type weapons to manage the selected player's restrictions.
+ *
+ * @param client    The client index.
+ */
+void WeaponsMenuWeaponsTypeTarget(int client, int target = 0)
+{
+	// Get target index from userid.
+	if (!target)
+		target = GetClientOfUserId(g_iWeaponsCurTarget[client]);
+	
+	// If the target is not available anymore, then stop.
+	if (!target)
+		return;
+
+	// Create menu handle.
+    Menu menu_weapons_type_target = new Menu(WeaponsMenuWeaponsTypeTargetHandle);
+
+    char typename[WEAPONS_MAX_LENGTH];
+    RestrictWeaponTypeGetName(g_iWeaponsCurType[client], typename, sizeof(typename));
+
+    // Set translation language.
+    SetGlobalTransTarget(client);
+
+    char title[MENU_LINE_TITLE_LENGTH];
+    char restrictall[MENU_LINE_REG_LENGTH];
+    char unrestrictall[MENU_LINE_REG_LENGTH];
+
+    Format(title, sizeof(title), "%t\n ", "Weapons menu restrict types weapon type title", typename);
+    Format(restrictall, sizeof(restrictall), "%t", "Weapons menu restrict types restrict all", typename);
+    Format(unrestrictall, sizeof(unrestrictall), "%t\n", "Weapons menu restrict types unrestrict all", typename);
+
+    // Draw items as selectable only if not all weapons within the type are restricted or unrestricted.
+    menu_weapons_type_target.SetTitle(title);
+    menu_weapons_type_target.AddItem("restrictall", restrictall, MenuGetItemDraw(!RestrictIsTypeClientRestricted(target, true, g_iWeaponsCurType[client])));
+    menu_weapons_type_target.AddItem("unrestrictall", unrestrictall, MenuGetItemDraw(!RestrictIsTypeClientRestricted(target, false, g_iWeaponsCurType[client])));
+
+    char typeweapon[MENU_LINE_SMALL_LENGTH];
+    char display[MENU_LINE_SMALL_LENGTH + 2]; // +2 to allow room for the [ ] if its restricted.
+
+    // Get an array populated with all weapons of the given type.
+    ArrayList arrayTypeWeapons;
+    int count = RestrictGetTypeWeapons(g_iWeaponsCurType[client], arrayTypeWeapons);
+
+    // x = Array index.
+    for (int x = 0; x < count; x++)
+    {
+        // Get weapon index to check restricted status of.
+        int weaponindex = arrayTypeWeapons.Get(x);
+
+        // Get name of weapon.
+        WeaponsGetName(weaponindex, typeweapon, sizeof(typeweapon));
+        strcopy(display, sizeof(display), typeweapon);
+
+        if (RestrictIsClientWeaponRestrict(target, weaponindex))
+        {
+            Format(display, sizeof(display), "[%s]", typeweapon);
+        }
+
+        // Disable option if it isn't toggleable.
+        menu_weapons_type_target.AddItem(typeweapon, display, MenuGetItemDraw(WeaponsGetToggleable(weaponindex)));
+    }
+
+    // Destroy the array handle.
+    delete arrayTypeWeapons;
+
+    // Set menu back button.
+    menu_weapons_type_target.ExitBackButton = true;
+
+    // Display menu to client.
+    menu_weapons_type_target.Display(client, MENU_TIME_FOREVER);
+}
+
+/**
+ * Called when client selects option in the per-player weapon group menu, and handles it.
+ *
+ * @param menu_weapons_type_target  	Handle of the menu being used.
+ * @param action                    	The action done on the menu (see menus.inc, enum MenuAction).
+ * @param client                    	The client index.
+ * @param slot                      	The slot index selected (starting from 0).
+ */
+public int WeaponsMenuWeaponsTypeTargetHandle(Menu menu_weapons_type_target, MenuAction action, int client, int slot)
+{
+    // Client selected an option.
+    if (action == MenuAction_Select)
+    {
+    	// Get the target index.
+    	int target = GetClientOfUserId(g_iWeaponsCurTarget[client]);
+    	
+    	// If target is not available anymore, then stop.
+    	if (!target)
+    	{
+    		WeaponsMenuPerPlayerRestrict(client);
+    		return 0;
+   		}
+
+        // Get name of current weapon type.
+        char typename[WEAPONS_MAX_LENGTH];
+        RestrictWeaponTypeGetName(g_iWeaponsCurType[client], typename, sizeof(typename));
+
+        bool single;
+        bool restrict;
+        char returntarget[WEAPONS_MAX_LENGTH];
+
+        switch(slot)
+        {
+            case 0:
+            {
+                // Restrict all weapons of this type.
+                restrict = true;
+                RestrictSetClientWeaponRestrict(target, typename, restrict);
+                LogAction(client, -1, "[ZR] %L Restricted weapon type : %s, for player: %L.", client, typename, target);
+                strcopy(returntarget, sizeof(returntarget), typename);
+            }
+            case 1:
+            {
+                // Unrestrict all weapons of this type.
+                restrict = false;
+                RestrictSetClientWeaponRestrict(target, typename, restrict);
+                LogAction(client, -1, "[ZR] %L Unrestricted weapon type : %s, for player: %L.", client, typename, target);
+                strcopy(returntarget, sizeof(returntarget), typename);
+            }
+            default:
+            {
+                // Get weappon name.
+                char typeweapon[MENU_LINE_REG_LENGTH];
+                menu_weapons_type_target.GetItem(slot, typeweapon, sizeof(typeweapon));
+
+                // Get weapon index.
+                int weaponindex = WeaponsNameToIndex(typeweapon);
+
+                // If weapon index is -1, then something went very wrong.
+                if (weaponindex == -1)
+                {
+                    delete menu_weapons_type_target;
+                    return -1;
+                }
+				
+                // If weapon isn't restricted, then restrict it.
+                if (!RestrictIsClientWeaponRestrict(target, weaponindex))
+                {
+                    // Restrict this weapon.
+                    restrict = true;
+                    single = true;
+                    RestrictSetClientWeaponRestrict(target, typeweapon, restrict);
+                    LogAction(client, -1, "[ZR] %L Restricted weapon type : %s, for player: %L.", client, typeweapon, target);
+                }
+                else
+                {
+                    // Unrestrict this weapon.
+                    restrict = false;
+                    single = true;
+                    RestrictSetClientWeaponRestrict(target, typeweapon, restrict);
+                    LogAction(client, -1, "[ZR] %L Unrestricted weapon type : %s, for player: %L.", client, typeweapon, target);
+                }
+                strcopy(returntarget, sizeof(returntarget), typeweapon);
+            }
+        }
+
+        // Print query response. Query_Successful because there is nothing we are really waiting for.
+        RestrictPrintQueryResponse(client, Query_Successful, single, restrict, returntarget);
+
+        // Resend menu.
+        WeaponsMenuWeaponsTypeTarget(client, target);
+    }
+    // Client closed the menu.
+    if (action == MenuAction_Cancel)
+    {
+        // Client hit "Back" button.
+        if (slot == MenuCancel_ExitBack)
+        {
+        	int target = GetClientOfUserId(g_iWeaponsCurTarget[client]);
+        	if (target)
+        		WeaponsMenuWeaponsTypesTarget(client, target)
+        	else
+            	WeaponsMenuPerPlayerRestrict(client);
+        }
+    }
+    // Client hit "Exit" button.
+    else if (action == MenuAction_End)
+    {
+        delete menu_weapons_type_target;
     }
     return -1;
 }

--- a/src/addons/sourcemod/scripting/zr/weapons/menu_weapons.inc
+++ b/src/addons/sourcemod/scripting/zr/weapons/menu_weapons.inc
@@ -726,7 +726,7 @@ public int WeaponsMenuWeaponsTypeTargetHandle(Menu menu_weapons_type_target, Men
         {
         	int target = GetClientOfUserId(g_iWeaponsCurTarget[client]);
         	if (target)
-        		WeaponsMenuWeaponsTypesTarget(client, target)
+        		WeaponsMenuWeaponsTypesTarget(client, target);
         	else
             	WeaponsMenuPerPlayerRestrict(client);
         }

--- a/src/addons/sourcemod/scripting/zr/weapons/restrict.inc
+++ b/src/addons/sourcemod/scripting/zr/weapons/restrict.inc
@@ -49,6 +49,11 @@ bool g_bRestrictBlockWeapon[MAXPLAYERS + 1];
 ArrayList arrayWeaponTypes = null;
 
 /**
+* Array to block any client from picking up specific weapons.
+*/
+bool g_bRestrictBlockWeaponOne[MAXPLAYERS + 1][WEAPONS_MAX_NUM];
+
+/**
 * Query results returned when (un)restricting a weapon.
 */
 enum RestrictQuery
@@ -131,6 +136,7 @@ void RestrictClientInit(int client)
 {
     SDKHook(client, SDKHook_WeaponCanUse, RestrictCanUse);
     g_bRestrictBlockWeapon[client] = false;
+    RestrictSetClientWeaponRestrictAll(client, false);
 }
 
 /**
@@ -247,9 +253,9 @@ public Action RestrictBuyCommand(int client, int argc)
         // Allow command.
         return Plugin_Continue;
     }
-
-    // If weapon is restricted, then stop.
-    if (RestrictIsWeaponRestricted(weaponindex))
+	
+    // If weapon is restricted or client cannot use it, then stop.
+    if (RestrictIsWeaponRestricted(weaponindex) || g_bRestrictBlockWeaponOne[client][weaponindex])
     {
         TranslationPrintToChat(client, "Weapon is restricted", weaponname);
 
@@ -799,4 +805,138 @@ public Action UnrestrictCommand(int client, int argc)
     }
 
     return Plugin_Handled;
+}
+
+/**
+* Set all wepaon restrict array for the specified client.
+* @param client    The client index.
+* @param value	   The restrict value
+* @noreturn        
+*/
+public void RestrictSetClientWeaponRestrictAll(int client, bool value)
+{
+    for (int i = 0; i < sizeof(g_bRestrictBlockWeaponOne[]); i++)
+	{
+		g_bRestrictBlockWeaponOne[client][i] = value;
+	}
+}
+
+/**
+* Set all wepaon restrict array for all clients.
+* @param value	   The restrict value
+* @noreturn        
+*/
+public void RestrictSetAllRestrictAll(bool value)
+{
+	for (int i = 1; i <= MaxClients; i++)
+	{
+	    for (int j = 0; j < sizeof(g_bRestrictBlockWeaponOne[]); j++)
+		{
+			g_bRestrictBlockWeaponOne[i][j] = value;
+		}
+	}
+}
+
+/**
+* Set weapon restrict value to a specific client.
+* @param client    		 The client index.
+* @param returntarget    The weapon or weapon type name.
+* @param value	   		 The restrict value
+* @noreturn        
+*/
+public bool RestrictSetClientWeaponRestrict(int client, const char[] returntarget, bool value)
+{
+	// Find index of the given weapon type.
+    int typeindex = RestrictTypeToIndex(returntarget);
+
+    // Single weapon.
+    if (typeindex == -1)
+    {
+        int weaponindex = WeaponsNameToIndex(returntarget);
+
+        // If weapon index is invalid, then return invalid.
+        if (weaponindex == -1)
+        {
+            return false;
+        }
+
+        g_bRestrictBlockWeaponOne[client][weaponindex] = value;
+        return true;
+    }
+    // Weapon type.
+    else
+    {
+        // Get all weapons in the given type.
+        ArrayList arrayTypeWeapons;
+        int count = RestrictGetTypeWeapons(typeindex, arrayTypeWeapons);
+
+        for (int x = 0; x < count; x++)
+        {
+            // Get weapon index.
+            int weaponindex = arrayTypeWeapons.Get(x);
+
+            g_bRestrictBlockWeaponOne[client][weaponindex] = value;
+        }
+
+        // Close handle
+        delete arrayTypeWeapons;
+
+        // Successfully restricted weapon type.
+        return true;
+    }
+}
+
+/**
+* Set weapon restrict value to all clients.
+* @param returntarget    The weapon or weapon type name.
+* @param value	   		 The restrict value
+* @noreturn        
+*/
+public bool RestrictSetAllWeaponRestrict(const char[] returntarget, bool value)
+{
+	// Find index of the given weapon type.
+    int typeindex = RestrictTypeToIndex(returntarget);
+
+    // Single weapon.
+    if (typeindex == -1)
+    {
+        int weaponindex = WeaponsNameToIndex(returntarget);
+
+        // If weapon index is invalid, then return invalid.
+        if (weaponindex == -1)
+        {
+            return false;
+        }
+		
+		for (int i = 1; i <= MaxClients; i++)
+		{
+        	g_bRestrictBlockWeaponOne[i][weaponindex] = value;
+        }
+        
+        return true;
+    }
+    // Weapon type.
+    else
+    {
+        // Get all weapons in the given type.
+        ArrayList arrayTypeWeapons;
+        int count = RestrictGetTypeWeapons(typeindex, arrayTypeWeapons);
+
+        for (int x = 0; x < count; x++)
+        {
+            // Get weapon index.
+            int weaponindex = arrayTypeWeapons.Get(x);
+
+            for (int i = 1; i <= MaxClients; i++)
+			{
+	        	g_bRestrictBlockWeaponOne[i][weaponindex] = value;
+	        }
+        }
+
+        // Close handle
+        delete arrayTypeWeapons;
+
+        // Successfully restricted weapon type.
+        return true;
+    }
 }

--- a/src/addons/sourcemod/scripting/zr/weapons/restrict.inc
+++ b/src/addons/sourcemod/scripting/zr/weapons/restrict.inc
@@ -253,7 +253,7 @@ public Action RestrictBuyCommand(int client, int argc)
         // Allow command.
         return Plugin_Continue;
     }
-	
+
     // If weapon is restricted or client cannot use it, then stop.
     if (RestrictIsWeaponRestricted(weaponindex) || RestrictIsClientWeaponRestrict(client, weaponindex))
     {

--- a/src/addons/sourcemod/scripting/zr/weapons/restrict.inc
+++ b/src/addons/sourcemod/scripting/zr/weapons/restrict.inc
@@ -808,6 +808,53 @@ public Action UnrestrictCommand(int client, int argc)
 }
 
 /**
+* Used to check if all weapons of a type are restricted for a specific player.
+*
+* @param client		   The Client index.
+* @param restricted    True to check if all weapons of given type are restricted.
+* @param index         The weapon type index.
+* @return              True if all weapons of the given type are restricted for that player or not, false if not.
+*/
+stock bool RestrictIsTypeClientRestricted(int client, bool restricted, int index)
+{
+    ArrayList arrayTypeWeapons;
+    int count = RestrictGetTypeWeapons(index, arrayTypeWeapons);
+
+    // x = array index
+    for (int x = 0; x < count; x++)
+    {
+        // Get weapon index to check restricted status of.
+        int weaponindex = arrayTypeWeapons.Get(x);
+
+        // If weapon is toggleable and it's not uniform with the given status, then return false.
+        if (WeaponsGetToggleable(weaponindex) && RestrictIsClientWeaponRestrict(client, weaponindex) != restricted)
+        {
+            // Close handle
+            delete arrayTypeWeapons;
+            return false;
+        }
+    }
+
+    // Close handle
+    delete arrayTypeWeapons;
+
+    // All weapons are restricted, so return true.
+    return true;
+}
+
+/**
+* Retrieves whether the specified weapon is restricted for the client.
+* @param client    The client index.
+* @param weapon	   The weapon index.
+* @noreturn        
+*/
+public bool RestrictIsClientWeaponRestrict(int client, int weapon)
+{
+	
+	return g_bRestrictBlockWeaponOne[client][weapon];
+}
+
+/**
 * Set all wepaon restrict array for the specified client.
 * @param client    The client index.
 * @param value	   The restrict value

--- a/src/addons/sourcemod/scripting/zr/weapons/restrict.inc
+++ b/src/addons/sourcemod/scripting/zr/weapons/restrict.inc
@@ -810,7 +810,7 @@ public Action UnrestrictCommand(int client, int argc)
 /**
 * Used to check if all weapons of a type are restricted for a specific player.
 *
-* @param client		   The Client index.
+* @param client        The Client index.
 * @param restricted    True to check if all weapons of given type are restricted.
 * @param index         The weapon type index.
 * @return              True if all weapons of the given type are restricted for that player or not, false if not.
@@ -853,45 +853,45 @@ stock bool RestrictIsClientWeaponRestrict(int client, int weapon)
     if (!g_hCvarsList.CVAR_WEAPONS_RESTRICT_PERPLAYER.BoolValue || !g_hCvarsList.CVAR_WEAPONS_RESTRICT.BoolValue)
         return false;
 
-	return g_bRestrictBlockWeaponOne[client][weapon];
+    return g_bRestrictBlockWeaponOne[client][weapon];
 }
 
 /**
 * Set all weapon restrict array for the specified client.
 * @param client    The client index.
-* @param value	   The restrict value
-* @noreturn        
+* @param value     The restrict value
+* @noreturn
 */
 stock void RestrictSetClientWeaponRestrictAll(int client, bool value)
 {
     for (int i = 0; i < sizeof(g_bRestrictBlockWeaponOne[]); i++)
-	{
-		g_bRestrictBlockWeaponOne[client][i] = value;
-	}
+    {
+        g_bRestrictBlockWeaponOne[client][i] = value;
+    }
 }
 
 /**
 * Set all weapon restrict array for all clients.
-* @param value	   The restrict value
-* @noreturn        
+* @param value     The restrict value
+* @noreturn
 */
 stock void RestrictSetAllRestrictAll(bool value)
 {
-	for (int i = 1; i <= MaxClients; i++)
-	{
-	    for (int j = 0; j < sizeof(g_bRestrictBlockWeaponOne[]); j++)
-		{
-			g_bRestrictBlockWeaponOne[i][j] = value;
-		}
-	}
+    for (int i = 1; i <= MaxClients; i++)
+    {
+        for (int j = 0; j < sizeof(g_bRestrictBlockWeaponOne[]); j++)
+        {
+            g_bRestrictBlockWeaponOne[i][j] = value;
+        }
+    }
 }
 
 /**
 * Set weapon restrict value to a specific client.
-* @param client    		 The client index.
-* @param weapon          The weapon or weapon type name.
-* @param value	   		 The restrict value
-* @noreturn        
+* @param client     The client index.
+* @param weapon     The weapon or weapon type name.
+* @param value      The restrict value
+* @noreturn
 */
 stock bool RestrictSetClientWeaponRestrict(int client, const char[] weapon, bool value)
 {
@@ -937,13 +937,13 @@ stock bool RestrictSetClientWeaponRestrict(int client, const char[] weapon, bool
 
 /**
 * Set weapon restrict value to all clients.
-* @param weapon    The weapon or weapon type name.
-* @param value	   		 The restrict value
-* @noreturn        
+* @param weapon     The weapon or weapon type name.
+* @param value      The restrict value
+* @noreturn
 */
 stock bool RestrictSetAllWeaponRestrict(const char[] weapon, bool value)
 {
-	// Find index of the given weapon type.
+    // Find index of the given weapon type.
     int typeindex = RestrictTypeToIndex(weapon);
 
     // Single weapon.
@@ -956,10 +956,10 @@ stock bool RestrictSetAllWeaponRestrict(const char[] weapon, bool value)
         {
             return false;
         }
-		
-		for (int i = 1; i <= MaxClients; i++)
-		{
-        	g_bRestrictBlockWeaponOne[i][weaponindex] = value;
+        
+        for (int i = 1; i <= MaxClients; i++)
+        {
+            g_bRestrictBlockWeaponOne[i][weaponindex] = value;
         }
         
         return true;
@@ -977,9 +977,9 @@ stock bool RestrictSetAllWeaponRestrict(const char[] weapon, bool value)
             int weaponindex = arrayTypeWeapons.Get(x);
 
             for (int i = 1; i <= MaxClients; i++)
-			{
-	        	g_bRestrictBlockWeaponOne[i][weaponindex] = value;
-	        }
+            {
+                g_bRestrictBlockWeaponOne[i][weaponindex] = value;
+            }
         }
 
         // Close handle

--- a/src/addons/sourcemod/scripting/zr/weapons/restrict.inc
+++ b/src/addons/sourcemod/scripting/zr/weapons/restrict.inc
@@ -255,7 +255,7 @@ public Action RestrictBuyCommand(int client, int argc)
     }
 	
     // If weapon is restricted or client cannot use it, then stop.
-    if (RestrictIsWeaponRestricted(weaponindex) || g_bRestrictBlockWeaponOne[client][weaponindex])
+    if (RestrictIsWeaponRestricted(weaponindex) || RestrictIsClientWeaponRestrict(client, weaponindex))
     {
         TranslationPrintToChat(client, "Weapon is restricted", weaponname);
 
@@ -846,10 +846,13 @@ stock bool RestrictIsTypeClientRestricted(int client, bool restricted, int index
 * Retrieves whether the specified weapon is restricted for the client.
 * @param client    The client index.
 * @param weapon	   The weapon index.
-* @noreturn        
+* @return          True if weapon was restricted for that client, false otherwise        
 */
-public bool RestrictIsClientWeaponRestrict(int client, int weapon)
+stock bool RestrictIsClientWeaponRestrict(int client, int weapon)
 {
+    if (!g_hCvarsList.CVAR_WEAPONS_RESTRICT_PERPLAYER.BoolValue || !g_hCvarsList.CVAR_WEAPONS_RESTRICT.BoolValue)
+        return false;
+
 	return g_bRestrictBlockWeaponOne[client][weapon];
 }
 
@@ -859,7 +862,7 @@ public bool RestrictIsClientWeaponRestrict(int client, int weapon)
 * @param value	   The restrict value
 * @noreturn        
 */
-public void RestrictSetClientWeaponRestrictAll(int client, bool value)
+stock void RestrictSetClientWeaponRestrictAll(int client, bool value)
 {
     for (int i = 0; i < sizeof(g_bRestrictBlockWeaponOne[]); i++)
 	{
@@ -872,7 +875,7 @@ public void RestrictSetClientWeaponRestrictAll(int client, bool value)
 * @param value	   The restrict value
 * @noreturn        
 */
-public void RestrictSetAllRestrictAll(bool value)
+stock void RestrictSetAllRestrictAll(bool value)
 {
 	for (int i = 1; i <= MaxClients; i++)
 	{
@@ -890,7 +893,7 @@ public void RestrictSetAllRestrictAll(bool value)
 * @param value	   		 The restrict value
 * @noreturn        
 */
-public bool RestrictSetClientWeaponRestrict(int client, const char[] weapon, bool value)
+stock bool RestrictSetClientWeaponRestrict(int client, const char[] weapon, bool value)
 {
 	// Find index of the given weapon type.
     int typeindex = RestrictTypeToIndex(weapon);
@@ -938,7 +941,7 @@ public bool RestrictSetClientWeaponRestrict(int client, const char[] weapon, boo
 * @param value	   		 The restrict value
 * @noreturn        
 */
-public bool RestrictSetAllWeaponRestrict(const char[] weapon, bool value)
+stock bool RestrictSetAllWeaponRestrict(const char[] weapon, bool value)
 {
 	// Find index of the given weapon type.
     int typeindex = RestrictTypeToIndex(weapon);

--- a/src/addons/sourcemod/scripting/zr/weapons/restrict.inc
+++ b/src/addons/sourcemod/scripting/zr/weapons/restrict.inc
@@ -850,7 +850,6 @@ stock bool RestrictIsTypeClientRestricted(int client, bool restricted, int index
 */
 public bool RestrictIsClientWeaponRestrict(int client, int weapon)
 {
-	
 	return g_bRestrictBlockWeaponOne[client][weapon];
 }
 
@@ -887,19 +886,19 @@ public void RestrictSetAllRestrictAll(bool value)
 /**
 * Set weapon restrict value to a specific client.
 * @param client    		 The client index.
-* @param returntarget    The weapon or weapon type name.
+* @param weapon          The weapon or weapon type name.
 * @param value	   		 The restrict value
 * @noreturn        
 */
-public bool RestrictSetClientWeaponRestrict(int client, const char[] returntarget, bool value)
+public bool RestrictSetClientWeaponRestrict(int client, const char[] weapon, bool value)
 {
 	// Find index of the given weapon type.
-    int typeindex = RestrictTypeToIndex(returntarget);
+    int typeindex = RestrictTypeToIndex(weapon);
 
     // Single weapon.
     if (typeindex == -1)
     {
-        int weaponindex = WeaponsNameToIndex(returntarget);
+        int weaponindex = WeaponsNameToIndex(weapon);
 
         // If weapon index is invalid, then return invalid.
         if (weaponindex == -1)
@@ -935,19 +934,19 @@ public bool RestrictSetClientWeaponRestrict(int client, const char[] returntarge
 
 /**
 * Set weapon restrict value to all clients.
-* @param returntarget    The weapon or weapon type name.
+* @param weapon    The weapon or weapon type name.
 * @param value	   		 The restrict value
 * @noreturn        
 */
-public bool RestrictSetAllWeaponRestrict(const char[] returntarget, bool value)
+public bool RestrictSetAllWeaponRestrict(const char[] weapon, bool value)
 {
 	// Find index of the given weapon type.
-    int typeindex = RestrictTypeToIndex(returntarget);
+    int typeindex = RestrictTypeToIndex(weapon);
 
     // Single weapon.
     if (typeindex == -1)
     {
-        int weaponindex = WeaponsNameToIndex(returntarget);
+        int weaponindex = WeaponsNameToIndex(weapon);
 
         // If weapon index is invalid, then return invalid.
         if (weaponindex == -1)

--- a/src/addons/sourcemod/scripting/zr/weapons/restrict.inc
+++ b/src/addons/sourcemod/scripting/zr/weapons/restrict.inc
@@ -855,7 +855,7 @@ public bool RestrictIsClientWeaponRestrict(int client, int weapon)
 }
 
 /**
-* Set all wepaon restrict array for the specified client.
+* Set all weapon restrict array for the specified client.
 * @param client    The client index.
 * @param value	   The restrict value
 * @noreturn        
@@ -869,7 +869,7 @@ public void RestrictSetClientWeaponRestrictAll(int client, bool value)
 }
 
 /**
-* Set all wepaon restrict array for all clients.
+* Set all weapon restrict array for all clients.
 * @param value	   The restrict value
 * @noreturn        
 */

--- a/src/addons/sourcemod/scripting/zr/weapons/weapons.inc
+++ b/src/addons/sourcemod/scripting/zr/weapons/weapons.inc
@@ -973,3 +973,47 @@ stock bool WeaponsIsClientInBuyZone(int client)
     // Return if client is in buyzone.
     return view_as<bool>(GetEntData(client, g_iToolsInBuyZone));
 }
+
+/**
+* Set all wepaon restrict array for the specified client.
+* @param client    The client index.
+* @param value	   The restrict value
+* @noreturn        
+*/
+public void WeaponsSetClientWeaponRestrictAll(int client, bool value)
+{
+    RestrictSetClientWeaponRestrictAll(client, value);
+}
+
+/**
+* Set all wepaon restrict array for all clients.
+* @param value	   The restrict value
+* @noreturn        
+*/
+public void WeaponsSetAllRestrictAll(bool value)
+{
+	RestrictSetAllRestrictAll(value);
+}
+
+/**
+* Set weapon restrict value to a specific client.
+* @param client    		 The client index.
+* @param returntarget    The weapon or weapon type name.
+* @param value	   		 The restrict value
+* @return				 True on success, false otherwise            
+*/
+public bool WeaponsSetClientWeaponRestrict(int client, const char[] returntarget, bool value)
+{
+	return RestrictSetClientWeaponRestrict(client, returntarget, value);
+}
+
+/**
+* Set weapon restrict value to all clients.
+* @param returntarget    The weapon or weapon type name.
+* @param value	   		 The restrict value
+* @return				 True on success, false otherwise        
+*/
+public bool WeaponsSetAllWeaponRestrict(const char[] returntarget, bool value)
+{
+	return RestrictSetAllWeaponRestrict(returntarget, value);
+}

--- a/src/addons/sourcemod/scripting/zr/weapons/weapons.inc
+++ b/src/addons/sourcemod/scripting/zr/weapons/weapons.inc
@@ -982,6 +982,9 @@ stock bool WeaponsIsClientInBuyZone(int client)
 */
 public void WeaponsSetClientWeaponRestrictAll(int client, bool value)
 {
+	if (!g_hCvarsList.CVAR_WEAPONS_RESTRICT_PERPLAYER.BoolValue)
+		return;
+
     RestrictSetClientWeaponRestrictAll(client, value);
 }
 
@@ -992,6 +995,9 @@ public void WeaponsSetClientWeaponRestrictAll(int client, bool value)
 */
 public void WeaponsSetAllRestrictAll(bool value)
 {
+	if (!g_hCvarsList.CVAR_WEAPONS_RESTRICT_PERPLAYER.BoolValue)
+		return;
+
 	RestrictSetAllRestrictAll(value);
 }
 
@@ -1004,6 +1010,9 @@ public void WeaponsSetAllRestrictAll(bool value)
 */
 public bool WeaponsSetClientWeaponRestrict(int client, const char[] returntarget, bool value)
 {
+	if (!g_hCvarsList.CVAR_WEAPONS_RESTRICT_PERPLAYER.BoolValue)
+		return false;
+
 	return RestrictSetClientWeaponRestrict(client, returntarget, value);
 }
 
@@ -1015,5 +1024,8 @@ public bool WeaponsSetClientWeaponRestrict(int client, const char[] returntarget
 */
 public bool WeaponsSetAllWeaponRestrict(const char[] returntarget, bool value)
 {
+	if (!g_hCvarsList.CVAR_WEAPONS_RESTRICT_PERPLAYER.BoolValue)
+		return false;
+
 	return RestrictSetAllWeaponRestrict(returntarget, value);
 }

--- a/src/addons/sourcemod/scripting/zr/weapons/weapons.inc
+++ b/src/addons/sourcemod/scripting/zr/weapons/weapons.inc
@@ -995,7 +995,7 @@ stock bool WeaponsIsClientInBuyZone(int client)
 */
 public void WeaponsSetClientWeaponRestrictAll(int client, bool value)
 {
-	if (!g_hCvarsList.CVAR_WEAPONS_RESTRICT_PERPLAYER.BoolValue)
+	if (!g_hCvarsList.CVAR_WEAPONS_RESTRICT_PERPLAYER.BoolValue || !g_hCvarsList.CVAR_WEAPONS_RESTRICT.BoolValue)
 		return;
 
     RestrictSetClientWeaponRestrictAll(client, value);
@@ -1008,7 +1008,7 @@ public void WeaponsSetClientWeaponRestrictAll(int client, bool value)
 */
 public void WeaponsSetAllRestrictAll(bool value)
 {
-	if (!g_hCvarsList.CVAR_WEAPONS_RESTRICT_PERPLAYER.BoolValue)
+	if (!g_hCvarsList.CVAR_WEAPONS_RESTRICT_PERPLAYER.BoolValue || !g_hCvarsList.CVAR_WEAPONS_RESTRICT.BoolValue)
 		return;
 
 	RestrictSetAllRestrictAll(value);
@@ -1017,28 +1017,28 @@ public void WeaponsSetAllRestrictAll(bool value)
 /**
 * Set weapon restrict value to a specific client.
 * @param client    		 The client index.
-* @param returntarget    The weapon or weapon type name.
+* @param weapon    The weapon or weapon type name.
 * @param value	   		 The restrict value
 * @return				 True on success, false otherwise            
 */
-public bool WeaponsSetClientWeaponRestrict(int client, const char[] returntarget, bool value)
+public bool WeaponsSetClientWeaponRestrict(int client, const char[] weapon, bool value)
 {
-	if (!g_hCvarsList.CVAR_WEAPONS_RESTRICT_PERPLAYER.BoolValue)
+	if (!g_hCvarsList.CVAR_WEAPONS_RESTRICT_PERPLAYER.BoolValue || !g_hCvarsList.CVAR_WEAPONS_RESTRICT.BoolValue)
 		return false;
 
-	return RestrictSetClientWeaponRestrict(client, returntarget, value);
+	return RestrictSetClientWeaponRestrict(client, weapon, value);
 }
 
 /**
 * Set weapon restrict value to all clients.
-* @param returntarget    The weapon or weapon type name.
+* @param weapon    The weapon or weapon type name.
 * @param value	   		 The restrict value
 * @return				 True on success, false otherwise        
 */
-public bool WeaponsSetAllWeaponRestrict(const char[] returntarget, bool value)
+public bool WeaponsSetAllWeaponRestrict(const char[] weapon, bool value)
 {
-	if (!g_hCvarsList.CVAR_WEAPONS_RESTRICT_PERPLAYER.BoolValue)
+	if (!g_hCvarsList.CVAR_WEAPONS_RESTRICT_PERPLAYER.BoolValue || !g_hCvarsList.CVAR_WEAPONS_RESTRICT.BoolValue)
 		return false;
 
-	return RestrictSetAllWeaponRestrict(returntarget, value);
+	return RestrictSetAllWeaponRestrict(weapon, value);
 }

--- a/src/addons/sourcemod/scripting/zr/weapons/weapons.inc
+++ b/src/addons/sourcemod/scripting/zr/weapons/weapons.inc
@@ -975,7 +975,7 @@ stock bool WeaponsIsClientInBuyZone(int client)
 }
 
 /**
-* Set all wepaon restrict array for the specified client.
+* Set all weapon restrict array for the specified client.
 * @param client    The client index.
 * @param value	   The restrict value
 * @noreturn        
@@ -989,7 +989,7 @@ public void WeaponsSetClientWeaponRestrictAll(int client, bool value)
 }
 
 /**
-* Set all wepaon restrict array for all clients.
+* Set all weapon restrict array for all clients.
 * @param value	   The restrict value
 * @noreturn        
 */

--- a/src/addons/sourcemod/scripting/zr/weapons/weapons.inc
+++ b/src/addons/sourcemod/scripting/zr/weapons/weapons.inc
@@ -989,56 +989,56 @@ stock bool WeaponsIsClientInBuyZone(int client)
 
 /**
 * Set all weapon restrict array for the specified client.
-* @param client    The client index.
-* @param value	   The restrict value
-* @noreturn        
+* @param client        The client index.
+* @param value         The restrict value
+* @noreturn
 */
 stock void WeaponsSetClientWeaponRestrictAll(int client, bool value)
 {
-	if (!g_hCvarsList.CVAR_WEAPONS_RESTRICT_PERPLAYER.BoolValue || !g_hCvarsList.CVAR_WEAPONS_RESTRICT.BoolValue)
-		return;
+    if (!g_hCvarsList.CVAR_WEAPONS_RESTRICT_PERPLAYER.BoolValue || !g_hCvarsList.CVAR_WEAPONS_RESTRICT.BoolValue)
+        return;
 
     RestrictSetClientWeaponRestrictAll(client, value);
 }
 
 /**
 * Set all weapon restrict array for all clients.
-* @param value	   The restrict value
-* @noreturn        
+* @param value        The restrict value
+* @noreturn 
 */
 stock void WeaponsSetAllRestrictAll(bool value)
 {
-	if (!g_hCvarsList.CVAR_WEAPONS_RESTRICT_PERPLAYER.BoolValue || !g_hCvarsList.CVAR_WEAPONS_RESTRICT.BoolValue)
-		return;
+    if (!g_hCvarsList.CVAR_WEAPONS_RESTRICT_PERPLAYER.BoolValue || !g_hCvarsList.CVAR_WEAPONS_RESTRICT.BoolValue)
+        return;
 
-	RestrictSetAllRestrictAll(value);
+    RestrictSetAllRestrictAll(value);
 }
 
 /**
 * Set weapon restrict value to a specific client.
-* @param client    		 The client index.
-* @param weapon    The weapon or weapon type name.
-* @param value	   		 The restrict value
-* @return				 True on success, false otherwise            
+* @param client        The client index.
+* @param weapon        The weapon or weapon type name.
+* @param value         The restrict value
+* @return              True on success, false otherwise
 */
 stock bool WeaponsSetClientWeaponRestrict(int client, const char[] weapon, bool value)
 {
-	if (!g_hCvarsList.CVAR_WEAPONS_RESTRICT_PERPLAYER.BoolValue || !g_hCvarsList.CVAR_WEAPONS_RESTRICT.BoolValue)
-		return false;
+    if (!g_hCvarsList.CVAR_WEAPONS_RESTRICT_PERPLAYER.BoolValue || !g_hCvarsList.CVAR_WEAPONS_RESTRICT.BoolValue)
+        return false;
 
-	return RestrictSetClientWeaponRestrict(client, weapon, value);
+    return RestrictSetClientWeaponRestrict(client, weapon, value);
 }
 
 /**
 * Set weapon restrict value to all clients.
-* @param weapon    The weapon or weapon type name.
-* @param value	   		 The restrict value
-* @return				 True on success, false otherwise        
+* @param weapon        The weapon or weapon type name.
+* @param value         The restrict value
+* @return              True on success, false otherwise
 */
 stock bool WeaponsSetAllWeaponRestrict(const char[] weapon, bool value)
 {
-	if (!g_hCvarsList.CVAR_WEAPONS_RESTRICT_PERPLAYER.BoolValue || !g_hCvarsList.CVAR_WEAPONS_RESTRICT.BoolValue)
-		return false;
+    if (!g_hCvarsList.CVAR_WEAPONS_RESTRICT_PERPLAYER.BoolValue || !g_hCvarsList.CVAR_WEAPONS_RESTRICT.BoolValue)
+        return false;
 
-	return RestrictSetAllWeaponRestrict(weapon, value);
+    return RestrictSetAllWeaponRestrict(weapon, value);
 }

--- a/src/addons/sourcemod/scripting/zr/weapons/weapons.inc
+++ b/src/addons/sourcemod/scripting/zr/weapons/weapons.inc
@@ -993,7 +993,7 @@ stock bool WeaponsIsClientInBuyZone(int client)
 * @param value	   The restrict value
 * @noreturn        
 */
-public void WeaponsSetClientWeaponRestrictAll(int client, bool value)
+stock void WeaponsSetClientWeaponRestrictAll(int client, bool value)
 {
 	if (!g_hCvarsList.CVAR_WEAPONS_RESTRICT_PERPLAYER.BoolValue || !g_hCvarsList.CVAR_WEAPONS_RESTRICT.BoolValue)
 		return;
@@ -1006,7 +1006,7 @@ public void WeaponsSetClientWeaponRestrictAll(int client, bool value)
 * @param value	   The restrict value
 * @noreturn        
 */
-public void WeaponsSetAllRestrictAll(bool value)
+stock void WeaponsSetAllRestrictAll(bool value)
 {
 	if (!g_hCvarsList.CVAR_WEAPONS_RESTRICT_PERPLAYER.BoolValue || !g_hCvarsList.CVAR_WEAPONS_RESTRICT.BoolValue)
 		return;
@@ -1021,7 +1021,7 @@ public void WeaponsSetAllRestrictAll(bool value)
 * @param value	   		 The restrict value
 * @return				 True on success, false otherwise            
 */
-public bool WeaponsSetClientWeaponRestrict(int client, const char[] weapon, bool value)
+stock bool WeaponsSetClientWeaponRestrict(int client, const char[] weapon, bool value)
 {
 	if (!g_hCvarsList.CVAR_WEAPONS_RESTRICT_PERPLAYER.BoolValue || !g_hCvarsList.CVAR_WEAPONS_RESTRICT.BoolValue)
 		return false;
@@ -1035,7 +1035,7 @@ public bool WeaponsSetClientWeaponRestrict(int client, const char[] weapon, bool
 * @param value	   		 The restrict value
 * @return				 True on success, false otherwise        
 */
-public bool WeaponsSetAllWeaponRestrict(const char[] weapon, bool value)
+stock bool WeaponsSetAllWeaponRestrict(const char[] weapon, bool value)
 {
 	if (!g_hCvarsList.CVAR_WEAPONS_RESTRICT_PERPLAYER.BoolValue || !g_hCvarsList.CVAR_WEAPONS_RESTRICT.BoolValue)
 		return false;

--- a/src/addons/sourcemod/scripting/zr/weapons/zmarket.inc
+++ b/src/addons/sourcemod/scripting/zr/weapons/zmarket.inc
@@ -1038,9 +1038,9 @@ stock bool ZMarketEquip(int client, const char[] weapon, bool rebuy = false)
     char weapondisplay[WEAPONS_MAX_LENGTH];
     WeaponsGetName(weaponindex, weapondisplay, sizeof(weapondisplay));
 
-    // Check to make sure the weapon isn't restricted.
+    // Check to make sure the weapon isn't restricted or player can use it.
     bool restricted = RestrictIsWeaponRestricted(weaponindex);
-    if (restricted)
+    if (restricted || g_bRestrictBlockWeaponOne[client][weaponindex])
     {
         TranslationPrintToChat(client, "Weapon is restricted", weapondisplay);
         return false;

--- a/src/addons/sourcemod/scripting/zr/weapons/zmarket.inc
+++ b/src/addons/sourcemod/scripting/zr/weapons/zmarket.inc
@@ -1040,7 +1040,7 @@ stock bool ZMarketEquip(int client, const char[] weapon, bool rebuy = false)
 
     // Check to make sure the weapon isn't restricted or player can use it.
     bool restricted = RestrictIsWeaponRestricted(weaponindex);
-    if (restricted || g_bRestrictBlockWeaponOne[client][weaponindex])
+    if (restricted || RestrictIsClientWeaponRestrict(client, weaponindex))
     {
         TranslationPrintToChat(client, "Weapon is restricted", weapondisplay);
         return false;


### PR DESCRIPTION
- Add new natives to support a per-client weapon restriction
- Makes other plugins use zr natives to handle anything related to weapons (In honor of GunGame funmode)