### PR TITLE
bump version

### DIFF
--- a/src/addons/sourcemod/scripting/zr/hgversion.h.inc
+++ b/src/addons/sourcemod/scripting/zr/hgversion.h.inc
@@ -4,7 +4,7 @@
 #define ZR_VER_BRANCH           "master"
 #define ZR_VER_MAJOR            "3"
 #define ZR_VER_MINOR            "12"
-#define ZR_VER_PATCH            "27"
+#define ZR_VER_PATCH            "28"
 #define ZR_VERSION              ZR_VER_MAJOR..."."...ZR_VER_MINOR..."."...ZR_VER_PATCH
 #define ZR_VER_LICENSE          "GNU GPL, Version 3"
-#define ZR_VER_DATE             "Fri Mar 06 15:15:00 CET 2026"
+#define ZR_VER_DATE             "Fri Mar 07 10:45:00 CET 2026"

--- a/src/addons/sourcemod/scripting/zr/weapons/weapons.inc
+++ b/src/addons/sourcemod/scripting/zr/weapons/weapons.inc
@@ -1010,7 +1010,7 @@ stock bool WeaponsHasPlayerItem(int client, const char[] weapon)
 		if (ent == -1)
 			continue;
 
-		char className[32];
+		char className[WEAPONS_MAX_LENGTH];
 		GetEntityClassname(ent, className, sizeof(className));
 		if (strcmp(className, weapon, false) == 0)
 			return true;

--- a/src/addons/sourcemod/scripting/zr/weapons/weapons.inc
+++ b/src/addons/sourcemod/scripting/zr/weapons/weapons.inc
@@ -1003,18 +1003,18 @@ stock bool WeaponsIsClientInBuyZone(int client)
  */
 stock bool WeaponsHasPlayerItem(int client, const char[] weapon)
 {
-	int max = GetEntPropArraySize(client, Prop_Send, "m_hMyWeapons");
-	for (int i = 0; i < max; i++)
-	{
-		int ent = GetEntPropEnt(client, Prop_Send, "m_hMyWeapons", i);
-		if (ent == -1)
-			continue;
+    int max = GetEntPropArraySize(client, Prop_Send, "m_hMyWeapons");
+    for (int i = 0; i < max; i++)
+    {
+        int ent = GetEntPropEnt(client, Prop_Send, "m_hMyWeapons", i);
+        if (ent == -1)
+            continue;
 
-		char className[WEAPONS_MAX_LENGTH];
-		GetEntityClassname(ent, className, sizeof(className));
-		if (strcmp(className, weapon, false) == 0)
-			return true;
-	}
+        char className[32];
+        GetEntityClassname(ent, className, sizeof(className));
+        if (strcmp(className, weapon, false) == 0)
+            return true;
+    }
 
-	return false;
+    return false;
 }

--- a/src/addons/sourcemod/scripting/zr/weapons/weapons.inc
+++ b/src/addons/sourcemod/scripting/zr/weapons/weapons.inc
@@ -994,3 +994,27 @@ stock bool WeaponsIsClientInBuyZone(int client)
     // Return if client is in buyzone.
     return view_as<bool>(GetEntData(client, g_iToolsInBuyZone));
 }
+
+/**
+ * Checks if the player has the specified weapon entity in inventory.
+ *
+ * @param client    The client index.
+ * @param weapon    The weapon entity name
+ */
+stock bool WeaponsHasPlayerItem(int client, const char[] weapon)
+{
+	int max = GetEntPropArraySize(client, Prop_Send, "m_hMyWeapons");
+	for (int i = 0; i < max; i++)
+	{
+		int ent = GetEntPropEnt(client, Prop_Send, "m_hMyWeapons", i);
+		if (ent == -1)
+			continue;
+
+		char className[32];
+		GetEntityClassname(ent, className, sizeof(className));
+		if (strcmp(className, weapon, false) == 0)
+			return true;
+	}
+
+	return false;
+}

--- a/src/addons/sourcemod/scripting/zr/weapons/weapons.inc
+++ b/src/addons/sourcemod/scripting/zr/weapons/weapons.inc
@@ -718,29 +718,22 @@ stock void WeaponsGetZMarketCommand(int index, char[] command, int maxlen)
  */
 stock bool WeaponsClientHasWeapon(int client, const char[] weapon)
 {
-    // Get all of client's current weapons.
-    int weapons[Slot_MAXSIZE];
-    WeaponsGetClientWeapons(client, weapons);
+    int max = GetEntPropArraySize(client, Prop_Send, "m_hMyWeapons");
+    if (!max)
+        return false;
 
-    char classname[64];
-
-    // x = slot index
-    for (int x = 0; x < WEAPONS_SLOTS_MAX; x++)
+    for (int i = 0; i < max; i++)
     {
-        // If slot is empty, then stop.
-        if (weapons[x] == -1)
-        {
+        int ent = GetEntPropEnt(client, Prop_Send, "m_hMyWeapons", i);
+        if (ent == -1 || !IsValidEntity(ent))
             continue;
-        }
 
-        // If the weapon's classname matches, then return true.
-        GetEdictClassname(weapons[x], classname, sizeof(classname));
-        if (strcmp(weapon, classname, false) == 0)
-        {
+        char className[32];
+        GetEntityClassname(ent, className, sizeof(className));
+        if (strcmp(className, weapon, false) == 0)
             return true;
-        }
     }
-
+    
     return false;
 }
 
@@ -993,28 +986,4 @@ stock bool WeaponsIsClientInBuyZone(int client)
 {
     // Return if client is in buyzone.
     return view_as<bool>(GetEntData(client, g_iToolsInBuyZone));
-}
-
-/**
- * Checks if the player has the specified weapon entity in inventory.
- *
- * @param client    The client index.
- * @param weapon    The weapon entity name
- */
-stock bool WeaponsHasPlayerItem(int client, const char[] weapon)
-{
-    int max = GetEntPropArraySize(client, Prop_Send, "m_hMyWeapons");
-    for (int i = 0; i < max; i++)
-    {
-        int ent = GetEntPropEnt(client, Prop_Send, "m_hMyWeapons", i);
-        if (ent == -1)
-            continue;
-
-        char className[32];
-        GetEntityClassname(ent, className, sizeof(className));
-        if (strcmp(className, weapon, false) == 0)
-            return true;
-    }
-
-    return false;
 }

--- a/src/addons/sourcemod/scripting/zr/weapons/weapons.inc
+++ b/src/addons/sourcemod/scripting/zr/weapons/weapons.inc
@@ -733,7 +733,7 @@ stock bool WeaponsClientHasWeapon(int client, const char[] weapon)
         if (strcmp(className, weapon, false) == 0)
             return true;
     }
-    
+
     return false;
 }
 
@@ -927,7 +927,7 @@ stock void WeaponsRemoveAllClientWeapons(int client, bool weaponsdrop)
     // Secondary (slot 1): at most 1 weapon.
     WeaponsClearClientWeaponSlot(client, Slot_Secondary, weaponsdrop);
 
-    // Melee/knife (slot 2): 
+    // Melee/knife (slot 2):
     // If removeknife is enabled, we strip all existing knives to prevent positioning glitches.
     // If disabled (e.g., for maps using custom knife items), we leave the current knife untouched.
     if (removeknife)

--- a/src/addons/sourcemod/scripting/zr/weapons/zmarket.inc
+++ b/src/addons/sourcemod/scripting/zr/weapons/zmarket.inc
@@ -1069,7 +1069,7 @@ stock bool ZMarketEquip(int client, const char[] weapon, bool rebuy = false)
         }
 
         // How many grenades does the client currently have?
-        int grenadecount = WeaponAmmoGetGrenadeCount(client, grenadetype);
+        int grenadecount = WeaponsHasPlayerItem(client, weaponentity) ? WeaponAmmoGetGrenadeCount(client, grenadetype) : 0;
 
         // How many grenades can the client hold?
         int grenadelimit = WeaponAmmoGetGrenadeLimit(grenadetype);

--- a/src/addons/sourcemod/scripting/zr/weapons/zmarket.inc
+++ b/src/addons/sourcemod/scripting/zr/weapons/zmarket.inc
@@ -1069,7 +1069,7 @@ stock bool ZMarketEquip(int client, const char[] weapon, bool rebuy = false)
         }
 
         // How many grenades does the client currently have?
-        int grenadecount = WeaponsHasPlayerItem(client, weaponentity) ? WeaponAmmoGetGrenadeCount(client, grenadetype) : 0;
+        int grenadecount = hasweapon ? WeaponAmmoGetGrenadeCount(client, grenadetype) : 0;
 
         // How many grenades can the client hold?
         int grenadelimit = WeaponAmmoGetGrenadeLimit(grenadetype);


### PR DESCRIPTION
The changes in this PR implement a more robust validation and cleanup process for the `m_iAmmo` table.

It ensures that:
*   Entries are explicitly cleared or validated against the actual inventory state.
*   The plugin performs a "sanity check" to detect if an entity indexed in the table still truly belongs to the player.
*   Synchronizes the internal plugin state with the actual game-world entity status to prevent "ghosting."