### PR TITLE
fix(respawn): correct ZR_Repsawn_Default typo

### DIFF
--- a/src/addons/sourcemod/scripting/include/zr/respawn.zr.inc
+++ b/src/addons/sourcemod/scripting/include/zr/respawn.zr.inc
@@ -30,11 +30,14 @@
  */
 enum ZR_RespawnCondition
 {
-    ZR_Repsawn_Default = -1,    /** Let ZR decide according to its settings. */
+    ZR_Respawn_Default = -1,    /** Let ZR decide according to its settings. */
     ZR_Respawn_Human = 0,       /** Respawn as a human. */
     ZR_Respawn_Zombie,          /** Respawn as a zombie. */
     ZR_Respawn_ZombieIfSuicide  /** Respawn as a zombie if killed by world damage. */
 }
+
+/** Deprecated misspelled alias, kept for source compat with existing third-party plugins. */
+#define ZR_Repsawn_Default ZR_Respawn_Default
 
 /**
  * Spawns a player into the round.
@@ -44,7 +47,7 @@ enum ZR_RespawnCondition
  *                          ZR settings. See ZR_RespawnCondition for details.
  * @error                   Invalid client index, not connected or already alive.
  */
-native void ZR_RespawnClient(int client, ZR_RespawnCondition condition = ZR_Repsawn_Default);
+native void ZR_RespawnClient(int client, ZR_RespawnCondition condition = ZR_Respawn_Default);
 
 /**
  * Called right before ZR is about to respawn a player.

--- a/src/addons/sourcemod/scripting/testsuite/zr/respawnapitest.sp
+++ b/src/addons/sourcemod/scripting/testsuite/zr/respawnapitest.sp
@@ -101,7 +101,7 @@ public Action RespawnClientCommand(int client, int argc)
         return Plugin_Handled;
     }
 
-    ZR_RespawnClient(target, ZR_Repsawn_Default);
+    ZR_RespawnClient(target, ZR_Respawn_Default);
 
     return Plugin_Handled;
 }

--- a/src/addons/sourcemod/scripting/zr/hgversion.h.inc
+++ b/src/addons/sourcemod/scripting/zr/hgversion.h.inc
@@ -4,7 +4,7 @@
 #define ZR_VER_BRANCH           "master"
 #define ZR_VER_MAJOR            "3"
 #define ZR_VER_MINOR            "13"
-#define ZR_VER_PATCH            "1"
+#define ZR_VER_PATCH            "2"
 #define ZR_VERSION              ZR_VER_MAJOR..."."...ZR_VER_MINOR..."."...ZR_VER_PATCH
 #define ZR_VER_LICENSE          "GNU GPL, Version 3"
-#define ZR_VER_DATE             "Thu Jun 18 CEST 2026"
+#define ZR_VER_DATE             "Sat Aug 22 CEST 2026"


### PR DESCRIPTION
## Summary
- Fix typo `ZR_Repsawn_Default` -> `ZR_Respawn_Default` in the public `ZR_RespawnCondition` enum and the `ZR_RespawnClient` native default parameter.
- Keep `ZR_Repsawn_Default` as a deprecated `#define` alias so third-party plugin source still referencing the misspelled symbol keeps compiling.
- Update internal testsuite usage to the corrected name.

## Test plan
- [ ] Build plugins and confirm `respawn.zr.inc` / `respawnapitest.sp` compile without errors