### PR TITLE
fix(config): close KeyValues handle on config parse failure

### DIFF
--- a/src/addons/sourcemod/scripting/zr/config.inc
+++ b/src/addons/sourcemod/scripting/zr/config.inc
@@ -762,8 +762,18 @@ stock bool ConfigOpenConfigFile(ConfigFile config, Handle &hConfig)
 		}
 		case Structure_Keyvalue:
 		{
-			hConfig = CreateKeyValues(configalias);
-			return FileToKeyValues(hConfig, configpath);
+			hConfig = new KeyValues(configalias);
+
+			// If the file couldn't be parsed, destroy the handle so callers
+			// that only check the return value don't leak it.
+			if (!FileToKeyValues(hConfig, configpath))
+			{
+				delete hConfig;
+				hConfig = null;
+				return false;
+			}
+
+			return true;
 		}
 	}
 	

--- a/src/addons/sourcemod/scripting/zr/config.inc
+++ b/src/addons/sourcemod/scripting/zr/config.inc
@@ -769,7 +769,6 @@ stock bool ConfigOpenConfigFile(ConfigFile config, Handle &hConfig)
 			if (!FileToKeyValues(hConfig, configpath))
 			{
 				delete hConfig;
-				hConfig = null;
 				return false;
 			}
 

--- a/src/addons/sourcemod/scripting/zr/hgversion.h.inc
+++ b/src/addons/sourcemod/scripting/zr/hgversion.h.inc
@@ -4,7 +4,7 @@
 #define ZR_VER_BRANCH           "master"
 #define ZR_VER_MAJOR            "3"
 #define ZR_VER_MINOR            "13"
-#define ZR_VER_PATCH            "2"
+#define ZR_VER_PATCH            "3"
 #define ZR_VERSION              ZR_VER_MAJOR..."."...ZR_VER_MINOR..."."...ZR_VER_PATCH
 #define ZR_VER_LICENSE          "GNU GPL, Version 3"
-#define ZR_VER_DATE             "Sat Aug 22 CEST 2026"
+#define ZR_VER_DATE             "Fri Sep 04 CEST 2026"


### PR DESCRIPTION
Closes #164

## Problem

`ConfigOpenConfigFile()` returned `FileToKeyValues()` directly after creating a
`KeyValues` handle. Callers (`ConfigLoadConfig`, `ConfigKeyvalueTreeSetting`)
only check the boolean and `return false` on failure, never deleting the out
handle - so every failed parse of a keyvalue config leaks a `KeyValues` handle.
Reachable repeatedly via `zr_config_reload` / `zr_config_reloadall` and the
`zr_class_modify` family.

## Fix

Delete the handle and null it on the failure path in `ConfigOpenConfigFile()`,
fixing all call sites at once. Also switches `CreateKeyValues` -> `new KeyValues`
for consistency with the rest of the file's modern syntax.

## Testing

- Build via existing CI.
- Manual: point a `zr_config_path_*` cvar at a malformed file, run
  `zr_config_reloadall` repeatedly, confirm `sm_dump_handles` no longer grows by
  one `KeyValues` per reload.