### PR TITLE
fix(models): fail state when a whole team has no precached model

### DIFF
--- a/src/addons/sourcemod/scripting/zr/hgversion.h.inc
+++ b/src/addons/sourcemod/scripting/zr/hgversion.h.inc
@@ -4,7 +4,7 @@
 #define ZR_VER_BRANCH           "master"
 #define ZR_VER_MAJOR            "3"
 #define ZR_VER_MINOR            "13"
-#define ZR_VER_PATCH            "13"
+#define ZR_VER_PATCH            "14"
 #define ZR_VERSION              ZR_VER_MAJOR..."."...ZR_VER_MINOR..."."...ZR_VER_PATCH
 #define ZR_VER_LICENSE          "GNU GPL, Version 3"
 #define ZR_VER_DATE             "Fri Sep 04 CEST 2026"

--- a/src/addons/sourcemod/scripting/zr/models.inc
+++ b/src/addons/sourcemod/scripting/zr/models.inc
@@ -255,6 +255,12 @@ public void ModelsOnConfigReload(ConfigFile config)
 
 /**
  * Precaches all models.
+ *
+ * An unprecached model can't be applied without risking a server crash. If a
+ * whole team ends up with none of its models precached, the plugin is stopped
+ * (LogType_Fatal) here - at map load and on `zr_config_reload models` - so the
+ * server owner fixes models.txt or the FastDL setup instead of running with
+ * zombies (or humans) stuck on the wrong model.
  */
 void ModelsPrecache()
 {
@@ -264,6 +270,10 @@ void ModelsPrecache()
     // check if we have hitboxchanger extension running
     bool hitboxchangerLoaded = (GetFeatureStatus(FeatureType_Native, "SetNumHitboxes") == FeatureStatus_Available);
 #endif
+
+    // Per-team tally: models configured vs models that actually precached.
+    int zombieCount, zombiePrecached;
+    int humanCount, humanPrecached;
 
     // Loop through all models, build full path and cache them.
     for (int model = 0; model < ModelCount; model++)
@@ -276,6 +286,41 @@ void ModelsPrecache()
 #else
         PrecacheModel(file);
 #endif
+
+        bool precached = IsModelPrecached(file);
+
+        switch (ModelsGetTeam(model))
+        {
+            case ModelTeam_Zombies:
+            {
+                zombieCount++;
+                if (precached)
+                {
+                    zombiePrecached++;
+                }
+            }
+            case ModelTeam_Humans:
+            {
+                humanCount++;
+                if (precached)
+                {
+                    humanPrecached++;
+                }
+            }
+        }
+    }
+
+    // A team that has models configured but none precached is unusable: applying
+    // any of them would risk crashing the server. Stop the plugin so the server
+    // owner fixes the model list / FastDL.
+    if (zombieCount && !zombiePrecached)
+    {
+        LogEvent(false, LogType_Fatal, LOG_CORE_EVENTS, LogModule_Models, "Config Validation", "None of the %d configured zombie model(s) could be precached. Check models.txt and that the model files exist on the server / FastDL.", zombieCount);
+    }
+
+    if (humanCount && !humanPrecached)
+    {
+        LogEvent(false, LogType_Fatal, LOG_CORE_EVENTS, LogModule_Models, "Config Validation", "None of the %d configured human model(s) could be precached. Check models.txt and that the model files exist on the server / FastDL.", humanCount);
     }
 }
 


### PR DESCRIPTION
Closes #165

## Problem

`ClassApplyModel()` checks `IsModelPrecached()` and, on a miss, logs a warning
and returns **without** calling `SetEntityModel()`. The player keeps whatever
model they currently have - right after infection / a team switch that's the
default human (CT) model, so the freshly infected zombie visually stays human.

A model ends up missing from the precache table when it wasn't part of
`ModelsPrecache()`'s map-load run: added to `models.txt` after map start,
(re)loaded through `zr_config_reload models`, files missing on the server /
FastDL, etc.

Handing an unprecached path to `SetEntityModel()` can crash the server, so this
PR does **not** try to force a model on anyway or swap in a random one. Instead
it draws a hard line at the point where the server is genuinely unusable.

## Fix

`ModelsPrecache()` now verifies its own result. It tallies, **per team**, how
many models were configured versus how many actually landed in the precache
table. If a team has models configured but **none** of them precached, the
plugin stops with `LogType_Fatal` → `SetFailState()`.

- Runs at map load **and** on `zr_config_reload models`.
- Forces the server owner to fix `models.txt` / the FastDL setup instead of
  running with zombies (or humans) stuck on the wrong model.
- Teams with **no** models configured are unaffected - e.g. the stock human
  classes, which use `model_path "default"` and never touch `models.txt`.

The narrower "one particular model of a team isn't precached, but others are"
case is **unchanged**: `ClassApplyModel()` still logs
`Warning: Model not precached, not applying model.` and leaves the player's
model as-is.

## How to reproduce

### Case A - a whole team has no usable model (the new fail state)

1. In `addons/sourcemod/configs/zr/models.txt`, break **every** `team "zombies"`
   entry: point each `name` / `path` at a `.mdl` that isn't on the server (or
   delete the real model files). Leave the entries in place so the list is
   "configured but broken".
2. `changelevel <map>`.
3. **After fix:** ZR refuses to run - the plugin fail-states during load:
   `None of the N configured zombie model(s) could be precached. Check models.txt and that the model files exist on the server / FastDL.`
   in the SourceMod error log; `sm plugins list` shows `zombiereloaded.smx` as
   failed.
4. Same via `zr_config_reload models` mid-map if the reload leaves a team with
   nothing precached.
5. **Before fix:** the server kept running; infected players silently stayed on
   the CT model.

### Case B - one model missing, team otherwise fine (unchanged)

1. Point one zombie class's `model_path` at a `.mdl` absent from `models.txt`
   while keeping the other zombie models intact.
2. `changelevel`, `zr_infect <bot>`.
3. Behaviour is the same before and after this PR: warning logged, the bot keeps
   its current model. Not addressed here by design.

### Pass criteria

- A server whose zombie (or human) team has no precached model **cannot start**
  - it fail-states with a clear message naming the offending team.
- A server with a valid model list is unaffected; stock configs still load.

## Notes

- The related `ClassOriginalPlayerModel` caching issue on zombie respawn is
  described in #165 and left for a follow-up.

## Testing

- Existing CI build.
- Manual: Case A above (fail state at load and on config reload).
