### PR TITLE
fix(models): stop truncating model paths to 63 characters

### DIFF
--- a/src/addons/sourcemod/scripting/zr/hgversion.h.inc
+++ b/src/addons/sourcemod/scripting/zr/hgversion.h.inc
@@ -4,7 +4,7 @@
 #define ZR_VER_BRANCH           "master"
 #define ZR_VER_MAJOR            "3"
 #define ZR_VER_MINOR            "13"
-#define ZR_VER_PATCH            "3"
+#define ZR_VER_PATCH            "4"
 #define ZR_VERSION              ZR_VER_MAJOR..."."...ZR_VER_MINOR..."."...ZR_VER_PATCH
 #define ZR_VER_LICENSE          "GNU GPL, Version 3"
 #define ZR_VER_DATE             "Fri Sep 04 CEST 2026"

--- a/src/addons/sourcemod/scripting/zr/models.inc
+++ b/src/addons/sourcemod/scripting/zr/models.inc
@@ -104,10 +104,10 @@ void ModelsLoad()
         }
 
         kvModels.GetString("name", name, sizeof(name));
-        strcopy(ModelData[ModelCount].Model_Name, 64, name);
+        strcopy(ModelData[ModelCount].Model_Name, sizeof(ModelData[].Model_Name), name);
 
         kvModels.GetString("path", path, sizeof(path));
-        strcopy(ModelData[ModelCount].Model_Path, 64, path);
+        strcopy(ModelData[ModelCount].Model_Path, sizeof(ModelData[].Model_Path), path);
 
         kvModels.GetString("team", team, sizeof(team));
         ModelData[ModelCount].Model_Team = ModelsStringToTeam(team);
@@ -116,7 +116,7 @@ void ModelsLoad()
         ModelData[ModelCount].Model_Access = ModelsStringToAccess(access);
 
         kvModels.GetString("group", group, sizeof(group));
-        strcopy(ModelData[ModelCount].Model_Group, 64, group);
+        strcopy(ModelData[ModelCount].Model_Group, sizeof(ModelData[].Model_Group), group);
 
 
         // Validate model attributes.


### PR DESCRIPTION
Closes #176. Part of #170.

## Problem

`Model_Path` is declared with room for a full path, but the parser copied only 64 bytes into it:

```sourcepawn
// zr/models.h.inc
char Model_Path[PLATFORM_MAX_PATH];     /* Path to model files. */

// zr/models.inc:110  (before)
strcopy(ModelData[ModelCount].Model_Path, 64, path);
```

Any `path` longer than 63 characters was silently truncated — and paths like `models/player/zombiereloaded/somepack/some_zombie_variant/` blow past that easily.

The truncation was invisible at load time, because validation runs against a *separate* buffer built from the untruncated `path`:

```sourcepawn
strcopy(buffer, sizeof(buffer), path);   // untruncated
StrCat(buffer, sizeof(buffer), name);
StrCat(buffer, sizeof(buffer), ".mdl");
if (!FileExists(buffer, false)) { ... }  // passes
```

So the model was counted as successfully loaded, while everything downstream read the *stored* truncated path: `ModelsGetFullPath()` built a path that doesn't exist, `ModelsPrecache()` precached nothing, and `ClassApplyModel()` later failed `IsModelPrecached()` — leaving the player with whatever model they had, which right after infection is the human/CT model.

This is a plausible root cause of #165.

## Fix

Use `sizeof()` on all three struct copies so the declared field size is the single source of truth, rather than a literal that can drift from the declaration.

## How to reproduce the bug (to verify the fix)

1. On a build **without** this patch, create a model directory whose path is longer than 63 characters, e.g.:

   ```
   models/player/zombiereloaded/testpack_long_directory_name/zombie_variant_one/
   ```

   (`models/player/zombiereloaded/testpack_long_directory_name/zombie_variant_one/` is 76 chars — anything over 63 works.)

2. Drop a valid `.mdl` + its `.vvd`/`.vtx`/materials in there and register it in `configs/zr/models.txt`:

   ```
   "zombie_variant_one"
   {
       "name"      "zombie_variant_one"
       "path"      "models/player/zombiereloaded/testpack_long_directory_name/zombie_variant_one/"
       "team"      "zombies"
       "access"    "public"
   }
   ```

3. Point a zombie class at that model in `configs/zr/playerclasses.txt`, or set `"model" "random_public"` with this as the only public zombie model.

4. Change map and get infected.

**Before:** the player stays in the human/CT model, and `logs/zombiereloaded/errors_*.log` shows
`Warning: Model not precached, not applying model. "models/player/zombiereloaded/testpack_long_direct"` — note the path cut mid-word at 63 chars. Model validation at load time reported **no** error for this model, which is what makes it confusing to diagnose.

**After:** the model applies normally and the log line is gone.

A quicker smoke test without touching models: `sm_dump_netprops`-style inspection isn't needed — just compare the path in the warning against the path in `models.txt`. If the logged path is a prefix of the configured one, you're hitting this bug.

## Version

Bumped to **3.13.4**.

> Note: this is one of 9 PRs opened from the review in #170, and each bumps `ZR_VER_PATCH`. Patch numbers were assigned in the merge order suggested in #170 (this one first). Expect a trivial conflict on `hgversion.h.inc` if they are merged out of order.

## Testing

- Builds clean on `spcomp` 1.12.0 (no warnings), same include set as CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
