### PR TITLE
fix(models): correct off-by-one that writes past the end of ModelData

### DIFF
--- a/src/addons/sourcemod/scripting/zr/hgversion.h.inc
+++ b/src/addons/sourcemod/scripting/zr/hgversion.h.inc
@@ -4,7 +4,7 @@
 #define ZR_VER_BRANCH           "master"
 #define ZR_VER_MAJOR            "3"
 #define ZR_VER_MINOR            "13"
-#define ZR_VER_PATCH            "3"
+#define ZR_VER_PATCH            "5"
 #define ZR_VERSION              ZR_VER_MAJOR..."."...ZR_VER_MINOR..."."...ZR_VER_PATCH
 #define ZR_VER_LICENSE          "GNU GPL, Version 3"
 #define ZR_VER_DATE             "Fri Sep 04 CEST 2026"

--- a/src/addons/sourcemod/scripting/zr/models.inc
+++ b/src/addons/sourcemod/scripting/zr/models.inc
@@ -95,10 +95,10 @@ void ModelsLoad()
     // Loop through all models and store attributes in ModelData array.
     do
     {
-        if (ModelCount > MODELS_MAX)
+        if (ModelCount >= MODELS_MAX)
         {
             // Maximum number of models reached. Log a warning and exit the loop.
-            LogEvent(false, LogType_Error, LOG_CORE_EVENTS, LogModule_Models, "Config Validation", "Warning: Maximum number of models reached (%d). Skipping other models.", MODELS_MAX + 1);
+            LogEvent(false, LogType_Error, LOG_CORE_EVENTS, LogModule_Models, "Config Validation", "Warning: Maximum number of models reached (%d). Skipping other models.", MODELS_MAX);
 
             break;
         }


### PR DESCRIPTION
Closes #171. Part of #170.

## Problem

`ModelData` has `MODELS_MAX` (48) slots, so valid indices are `0..47`. The bound check in the parse loop used `>` instead of `>=`:

```sourcepawn
// zr/models.inc:98  (before)
if (ModelCount > MODELS_MAX)
```

With 48 models already parsed the condition reads `48 > 48` → false, the loop falls through, and `ModelData[48]` is written — one past the end. SourcePawn bounds-checks array writes at runtime, so this raises `Array index out of bounds (index 48, limit 48)` and **aborts `ModelsLoad()` entirely**: every model after that point fails to load, and depending on where it dies you can end up with no usable models at all.

The `MODELS_MAX + 1` in the log message was wrong for the same reason — the real limit is `MODELS_MAX`.

## Cross-check

The equivalent loop for classes already does this correctly in this repo:

```sourcepawn
// zr/playerclasses/playerclasses.inc:625
if (ClassCount >= ZR_CLASS_MAX)
```

`models.inc:98` was the only remaining `Count > *_MAX` comparison in the codebase.

## How to reproduce the bug (to verify the fix)

1. On a build **without** this patch, put **49 or more** valid entries in `configs/zr/models.txt`. They must all pass validation (real files on disk, valid `team`/`access`), since failed entries don't increment `ModelCount`.

   A quick way to get there without shipping 49 model packs: duplicate one working entry 49 times under different section names but pointing at the same `name`/`path`. Validation only checks that the files exist, so duplicates count.

2. Change map (or `sm plugins reload zombiereloaded`).

3. Check `logs/errors_*.log` (SourceMod's own error log, not the ZR one):

   **Before:**
   ```
   [SM] Exception reported: Array index out-of-bounds (index 48, limit 48)
   [SM] Blaming: zombiereloaded.smx
   [SM] Call stack trace:
   [SM]   [0] ModelsLoad
   ```
   and ZR's `Successful: N | Unsuccessful: N` summary line never appears.

   **After:** loading stops cleanly at 48 with
   `Warning: Maximum number of models reached (48). Skipping other models.`
   and the summary line is printed normally.

Note the message now says `48` rather than the previous (incorrect) `49`.

## Version

Bumped to **3.13.5**.

> Note: one of 9 PRs from the review in #170; each bumps `ZR_VER_PATCH`. Patch numbers follow the merge order suggested there (this is #2, after #180). Expect a trivial conflict on `hgversion.h.inc` if merged out of order.

## Testing

- Builds clean on `spcomp` 1.12.0 (no warnings), same include set as CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
