### PR TITLE
fix(models): log the directory, not a null handle, when OpenDirectory fails

### DIFF
--- a/src/addons/sourcemod/scripting/zr/hgversion.h.inc
+++ b/src/addons/sourcemod/scripting/zr/hgversion.h.inc
@@ -4,7 +4,7 @@
 #define ZR_VER_BRANCH           "master"
 #define ZR_VER_MAJOR            "3"
 #define ZR_VER_MINOR            "13"
-#define ZR_VER_PATCH            "3"
+#define ZR_VER_PATCH            "6"
 #define ZR_VERSION              ZR_VER_MAJOR..."."...ZR_VER_MINOR..."."...ZR_VER_PATCH
 #define ZR_VER_LICENSE          "GNU GPL, Version 3"
 #define ZR_VER_DATE             "Fri Sep 04 CEST 2026"

--- a/src/addons/sourcemod/scripting/zr/models.inc
+++ b/src/addons/sourcemod/scripting/zr/models.inc
@@ -171,7 +171,8 @@ void ModelsLoad()
         // Check if failed.
         if (dir == null)
         {
-            LogEvent(false, LogType_Error, LOG_CORE_EVENTS, LogModule_Models, "Config Validation", "Error opening directory: %s", dir);
+            LogEvent(false, LogType_Error, LOG_CORE_EVENTS, LogModule_Models, "Config Validation", "Error opening directory: \"%s\"", path);
+            failedCount++;
             continue;
         }
 


### PR DESCRIPTION
Closes #172. Part of #170.

## Problem

The `OpenDirectory()` failure path formatted the *handle* with `%s`, on a branch where it is known to be `null`:

```sourcepawn
// zr/models.inc:169-176  (before)
DirectoryListing dir = OpenDirectory(path);

if (dir == null)
{
    LogEvent(..., "Error opening directory: %s", dir);   // dir is null here
    continue;
}
```

The format routine treats address `0` as a string, which raises `Invalid memory access` and aborts config loading — in the very path that exists to *report* a misconfiguration. So a bad `path` in `models.txt` takes down the whole models loader instead of logging one warning and moving on.

The plugin's own documentation confirms the intent was to print the directory:

> `models` / `error` / `Error opening directory: <directory>` (`docs/index.html:5360`)

## Secondary fix in the same block

Every other validation failure in this loop increments `failedCount`, which feeds the final `Successful: %d | Unsuccessful: %d` summary and the `index %d` reported by subsequent failures. The `OpenDirectory` branch was the only `continue` that skipped it, so a directory that failed to open went uncounted and shifted the indices reported afterwards. Now incremented like the others.

## How to reproduce the bug (to verify the fix)

1. On a build **without** this patch, add an entry to `configs/zr/models.txt` whose `path` points at a directory that does not exist, but arrange for the `.mdl` check just above it to pass.

   That second part matters: the `FileExists(buffer)` check at line 128 runs first and would `continue` early for a plain typo'd path. To land on the `OpenDirectory` branch you need a path where the `.mdl` file resolves but `OpenDirectory` fails. The reliable way to get there is a path inside a **VPK / workshop-packed** directory: `FileExists(..., false)` finds the packed file, while `OpenDirectory()` only walks the real filesystem and returns `null`.

   ```
   "packed_zombie"
   {
       "name"      "packed_zombie"
       "path"      "models/player/some_vpk_packed_dir/"
       "team"      "zombies"
       "access"    "public"
   }
   ```

2. Change map and watch `logs/errors_*.log`:

   **Before:**
   ```
   [SM] Exception reported: Invalid memory access
   [SM] Blaming: zombiereloaded.smx
   [SM] Call stack trace:
   [SM]   [0] ModelsLoad
   ```
   Loading stops there — models listed after this entry never load.

   **After:**
   ```
   Error opening directory: "models/player/some_vpk_packed_dir/"
   ```
   and loading continues through the rest of the file. The final summary line also now counts this entry under `Unsuccessful`.

If you can't easily set up a VPK case, you can confirm the fix statically: the log line now carries the configured path instead of an empty/garbled token.

## Version

Bumped to **3.13.6**.

> Note: one of 9 PRs from the review in #170; each bumps `ZR_VER_PATCH`. Patch numbers follow the merge order suggested there (this is #3, after #180 and #181). Expect a trivial conflict on `hgversion.h.inc` if merged out of order.

## Testing

- Builds clean on `spcomp` 1.12.0 (no warnings), same include set as CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
