### PR TITLE
fix(event): validate GetClientOfUserId() in player_team and player_jump

### DIFF
--- a/src/addons/sourcemod/scripting/zr/event.inc
+++ b/src/addons/sourcemod/scripting/zr/event.inc
@@ -156,6 +156,14 @@ public Action EventPlayerTeam(Event event, const char[] name, bool dontBroadcast
     int index = GetClientOfUserId(event.GetInt("userid"));
     int team = event.GetInt("team");
 
+    // The engine fires player_team while a client is disconnecting, so the
+    // userid may no longer map to a client. Client index 0 is invalid for
+    // every client native below.
+    if (!ZRIsClientValid(index))
+    {
+        return Plugin_Handled;
+    }
+
     // Forward event to modules.
     InfectOnClientTeam(index, team);
     ImmunityOnClientTeam(index);
@@ -295,6 +303,13 @@ public Action EventPlayerJump(Event event, const char[] name, bool dontBroadcast
 {
     // Get all required event info.
     int index = GetClientOfUserId(event.GetInt("userid"));
+
+    // The userid may no longer map to a client. Client index 0 is invalid for
+    // the client natives used in the post callback.
+    if (!ZRIsClientValid(index))
+    {
+        return Plugin_Continue;
+    }
 
     // Fire post player_jump event.
     CreateTimer(0.0, EventPlayerJumpPost, index);

--- a/src/addons/sourcemod/scripting/zr/event.inc
+++ b/src/addons/sourcemod/scripting/zr/event.inc
@@ -154,7 +154,6 @@ public Action EventPlayerTeam(Event event, const char[] name, bool dontBroadcast
 {
     // Get all required event info.
     int index = GetClientOfUserId(event.GetInt("userid"));
-    int team = event.GetInt("team");
 
     // The engine fires player_team while a client is disconnecting, so the
     // userid may no longer map to a client. Client index 0 is invalid for
@@ -163,6 +162,8 @@ public Action EventPlayerTeam(Event event, const char[] name, bool dontBroadcast
     {
         return Plugin_Handled;
     }
+
+    int team = event.GetInt("team");
 
     // Forward event to modules.
     InfectOnClientTeam(index, team);

--- a/src/addons/sourcemod/scripting/zr/hgversion.h.inc
+++ b/src/addons/sourcemod/scripting/zr/hgversion.h.inc
@@ -4,7 +4,7 @@
 #define ZR_VER_BRANCH           "master"
 #define ZR_VER_MAJOR            "3"
 #define ZR_VER_MINOR            "13"
-#define ZR_VER_PATCH            "3"
+#define ZR_VER_PATCH            "7"
 #define ZR_VERSION              ZR_VER_MAJOR..."."...ZR_VER_MINOR..."."...ZR_VER_PATCH
 #define ZR_VER_LICENSE          "GNU GPL, Version 3"
 #define ZR_VER_DATE             "Fri Sep 04 CEST 2026"


### PR DESCRIPTION
Closes #173. Part of #170.

## Problem

`GetClientOfUserId()` returns `0` when the userid no longer maps to a connected client. Client index `0` is invalid for every client native — those raise `Client index 0 is invalid` rather than returning `false`. Two handlers used the result unguarded.

### `player_team` — `zr/event.inc:153`

```sourcepawn
int index = GetClientOfUserId(event.GetInt("userid"));
int team = event.GetInt("team");

InfectOnClientTeam(index, team);
ImmunityOnClientTeam(index);

if (IsFakeClient(index) && !IsClientSourceTV(index))   // errors when index == 0
```

The engine fires `player_team` while a client is **disconnecting** (the leaver is moved to "unassigned"), so this is not an edge case — it fires routinely on a busy server.

### `player_jump` — `zr/event.inc:294`

```sourcepawn
int index = GetClientOfUserId(event.GetInt("userid"));
CreateTimer(0.0, EventPlayerJumpPost, index);
```

Here the invalid index is deferred into a timer, where `EventPlayerJumpPost` calls `IsClientInGame(client)` — which also errors on `0`.

## Fix

Guard both with the existing `ZRIsClientValid()` helper, matching how `EventPlayerDeath()` and `EventPlayerSpawn()` in the same file already handle it.

The `IsClientInGame()` check inside `EventPlayerJumpPost` is deliberately **kept**: `ZRIsClientValid` is only a range check, and the client can still leave between the event and the next frame.

## How to reproduce the bug (to verify the fix)

The `player_team` path is the easy one and needs no special setup.

1. On a build **without** this patch, run a populated server (bots are fine: `bot_add` a few) and enable SourceMod error logging.
2. Have players **disconnect while on a team** — `sm_kick`, a bot quitting, or just normal churn. Map changes with players connected also work.
3. Watch `logs/errors_*.log`:

   **Before:**
   ```
   [SM] Exception reported: Client index 0 is invalid
   [SM] Blaming: zombiereloaded.smx
   [SM] Call stack trace:
   [SM]   [0] IsFakeClient
   [SM]   [1] Line 164, zr/event.inc::EventPlayerTeam
   ```

   **After:** no such entries.

A tighter repro if you want it deterministic: `sm_cvar bot_quota 10` then `sm_cvar bot_quota 0` — every bot removal fires `player_team` for a userid that is already gone, so you get one exception per bot on an unpatched build and none after.

For the `player_jump` path, the window is narrower (a jump in the same frame the player drops), so it shows up as occasional `Client index 0 is invalid` blamed on `IsClientInGame` / `EventPlayerJumpPost` rather than something you can force on demand.

## Version

Bumped to **3.13.7**.

> Note: one of 9 PRs from the review in #170; each bumps `ZR_VER_PATCH`. Patch numbers follow the merge order suggested there. Expect a trivial conflict on `hgversion.h.inc` if merged out of order.

## Testing

- Builds clean on `spcomp` 1.12.0 (no warnings), same include set as CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
