### PR TITLE
fix(zmarket): stop closing the mp_startmoney ConVar handle

### DIFF
--- a/src/addons/sourcemod/scripting/zr/cvars.inc
+++ b/src/addons/sourcemod/scripting/zr/cvars.inc
@@ -212,6 +212,7 @@ ConVar CvarsGetPermissionFlagConfiguration()
 ConVar g_hAutoTeamBalance;
 ConVar g_hLimitTeams;
 ConVar g_hRestartGame;
+ConVar g_hStartMoney;
 /**
  * @endsection
  */
@@ -225,6 +226,7 @@ void CvarsInit()
     g_hAutoTeamBalance = FindConVar("mp_autoteambalance");
     g_hLimitTeams = FindConVar("mp_limitteams");
     g_hRestartGame = FindConVar("mp_restartgame");
+    g_hStartMoney = FindConVar("mp_startmoney");
 
     // Create zombiereloaded cvars.
     CvarsCreate();

--- a/src/addons/sourcemod/scripting/zr/hgversion.h.inc
+++ b/src/addons/sourcemod/scripting/zr/hgversion.h.inc
@@ -4,7 +4,7 @@
 #define ZR_VER_BRANCH           "master"
 #define ZR_VER_MAJOR            "3"
 #define ZR_VER_MINOR            "13"
-#define ZR_VER_PATCH            "3"
+#define ZR_VER_PATCH            "8"
 #define ZR_VERSION              ZR_VER_MAJOR..."."...ZR_VER_MINOR..."."...ZR_VER_PATCH
 #define ZR_VER_LICENSE          "GNU GPL, Version 3"
 #define ZR_VER_DATE             "Fri Sep 04 CEST 2026"

--- a/src/addons/sourcemod/scripting/zr/weapons/zmarket.inc
+++ b/src/addons/sourcemod/scripting/zr/weapons/zmarket.inc
@@ -939,12 +939,12 @@ public Action CommandPlayerBuy(int client, const char[] command, int argc)
     if (!(zmarketfreespawn && !InfectHasZombieSpawned()))
         return Plugin_Continue;
 
-    ConVar cv_StartMoney = FindConVar("mp_startmoney");
-    if (cv_StartMoney == null)
+    // Cached in CvarsInit(). ConVar handles are owned by SourceMod and must
+    // never be closed by the plugin.
+    if (g_hStartMoney == null)
         return Plugin_Continue;
 
-    int iDefaultCash = GetConVarInt(cv_StartMoney);
-    delete cv_StartMoney;
+    int iDefaultCash = g_hStartMoney.IntValue;
 
     DataPack hPack = new DataPack();
     hPack.WriteCell(GetClientUserId(client));


### PR DESCRIPTION
Closes #174. Part of #170.

## Problem

`CommandPlayerBuy()` looked up `mp_startmoney` and then closed the handle:

```sourcepawn
// zr/weapons/zmarket.inc:942-947  (before)
ConVar cv_StartMoney = FindConVar("mp_startmoney");
if (cv_StartMoney == null)
    return Plugin_Continue;

int iDefaultCash = GetConVarInt(cv_StartMoney);
delete cv_StartMoney;
```

ConVar handles are owned by SourceMod's ConVarManager, not by the plugin. They are meant to be looked up once and kept — closing one is an error.

This runs on **every `buy` command** while `zr_weapons_zmarket_freespawn` is enabled and no zombie has spawned yet, so it repeats constantly throughout the human phase of every round.

## Fix

Cache `mp_startmoney` in `CvarsInit()` alongside the other game ConVars, which is the pattern this codebase already uses:

```sourcepawn
// zr/cvars.inc
g_hAutoTeamBalance = FindConVar("mp_autoteambalance");
g_hLimitTeams      = FindConVar("mp_limitteams");
g_hRestartGame     = FindConVar("mp_restartgame");
g_hStartMoney      = FindConVar("mp_startmoney");   // added
```

and read it with `.IntValue` to match the surrounding style. The null check is preserved.

`zmarket.inc:947` was the only `delete` on a `FindConVar()` result in the repo.

## How to reproduce the bug (to verify the fix)

1. On a build **without** this patch:
   ```
   sm_cvar zr_weapons_zmarket_freespawn 1
   ```
2. Start a round and, **before the mother zombie spawns**, type `buy` (or open the buy menu and purchase anything) as a human.
3. Watch `logs/errors_*.log`:

   **Before:** an entry per `buy`, blamed on `zombiereloaded.smx` at `CommandPlayerBuy`, reporting an invalid/closed handle. Repeat the `buy` a few times and the log grows one entry per invocation — that repetition is the tell.

   **After:** no entries, and the free-spawn refund still works (your cash returns to `mp_startmoney` on the next frame).

Functional check that the refund itself didn't regress: set `sm_cvar mp_startmoney 16000`, buy a rifle during the human phase, and confirm your money is back at 16000 immediately after the purchase completes.

## Version

Bumped to **3.13.8**.

> Note: one of 9 PRs from the review in #170; each bumps `ZR_VER_PATCH`. Patch numbers follow the merge order suggested there. Expect a trivial conflict on `hgversion.h.inc` if merged out of order. This PR also touches `cvars.inc`, as does #175 — they touch adjacent but distinct lines.

## Testing

- Builds clean on `spcomp` 1.12.0 (no warnings), same include set as CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
