### PR TITLE
fix(cvars): null-check mp_roundtime and sv_alltalk before dereferencing

### DIFF
--- a/src/addons/sourcemod/scripting/zr/cvars.inc
+++ b/src/addons/sourcemod/scripting/zr/cvars.inc
@@ -213,6 +213,8 @@ ConVar g_hAutoTeamBalance;
 ConVar g_hLimitTeams;
 ConVar g_hRestartGame;
 ConVar g_hStartMoney;
+ConVar g_hRoundTime;
+ConVar g_hAllTalk;
 /**
  * @endsection
  */
@@ -227,6 +229,8 @@ void CvarsInit()
     g_hLimitTeams = FindConVar("mp_limitteams");
     g_hRestartGame = FindConVar("mp_restartgame");
     g_hStartMoney = FindConVar("mp_startmoney");
+    g_hRoundTime = FindConVar("mp_roundtime");
+    g_hAllTalk = FindConVar("sv_alltalk");
 
     // Create zombiereloaded cvars.
     CvarsCreate();

--- a/src/addons/sourcemod/scripting/zr/hgversion.h.inc
+++ b/src/addons/sourcemod/scripting/zr/hgversion.h.inc
@@ -4,7 +4,7 @@
 #define ZR_VER_BRANCH           "master"
 #define ZR_VER_MAJOR            "3"
 #define ZR_VER_MINOR            "13"
-#define ZR_VER_PATCH            "8"
+#define ZR_VER_PATCH            "9"
 #define ZR_VERSION              ZR_VER_MAJOR..."."...ZR_VER_MINOR..."."...ZR_VER_PATCH
 #define ZR_VER_LICENSE          "GNU GPL, Version 3"
 #define ZR_VER_DATE             "Fri Sep 04 CEST 2026"

--- a/src/addons/sourcemod/scripting/zr/roundend.inc
+++ b/src/addons/sourcemod/scripting/zr/roundend.inc
@@ -171,8 +171,14 @@ void RoundEndOnRoundStart()
 void RoundEndOnRoundFreezeEnd()
 {
     // Calculate round length, in seconds.
-    // Get mp_roundtime. (in minutes)
-    float roundtime = FindConVar("mp_roundtime").FloatValue;
+    // Get mp_roundtime. (in minutes) - cached in CvarsInit().
+    if (g_hRoundTime == null)
+    {
+        LogError("[ZR] Can't find \"mp_roundtime\", round end timer not started.");
+        return;
+    }
+
+    float roundtime = g_hRoundTime.FloatValue;
 
     // Convert to seconds.
     roundtime *= 60.0;

--- a/src/addons/sourcemod/scripting/zr/roundend.inc
+++ b/src/addons/sourcemod/scripting/zr/roundend.inc
@@ -172,9 +172,14 @@ void RoundEndOnRoundFreezeEnd()
 {
     // Calculate round length, in seconds.
     // Get mp_roundtime. (in minutes) - cached in CvarsInit().
+    static bool s_LoggedMissingRoundTime;
     if (g_hRoundTime == null)
     {
-        LogError("[ZR] Can't find \"mp_roundtime\", round end timer not started.");
+        if (!s_LoggedMissingRoundTime)
+        {
+            LogError("[ZR] Can't find \"mp_roundtime\", round end timer not started.");
+            s_LoggedMissingRoundTime = true;
+        }
         return;
     }
 

--- a/src/addons/sourcemod/scripting/zr/soundeffects/voice.inc
+++ b/src/addons/sourcemod/scripting/zr/soundeffects/voice.inc
@@ -217,8 +217,9 @@ stock bool VoiceIsClientMuted(int client)
  */
 stock void VoiceReset()
 {
-    // Is alltalk enabled?
-    bool alltalk = GetConVarBool(FindConVar("sv_alltalk"));
+    // Is alltalk enabled? (sv_alltalk is cached in CvarsInit(); treat a
+    // missing cvar as disabled rather than dereferencing null.)
+    bool alltalk = (g_hAllTalk != null) && g_hAllTalk.BoolValue;
 
     // Determine new voice flags based off of alltalk.
     int voiceflags = alltalk ? VOICE_SPEAKALL | VOICE_LISTENALL : VOICE_TEAM | VOICE_LISTENTEAM;


### PR DESCRIPTION
Closes #175. Part of #170.

## Problem

Two `FindConVar()` lookups were dereferenced in the same expression, with no null check. `FindConVar()` returns `null` when the ConVar doesn't exist.

```sourcepawn
// zr/roundend.inc:175  (before)
float roundtime = FindConVar("mp_roundtime").FloatValue;

// zr/soundeffects/voice.inc:221  (before)
bool alltalk = GetConVarBool(FindConVar("sv_alltalk"));
```

`mp_roundtime` is the more serious of the two: `RoundEndOnRoundFreezeEnd()` runs at the end of every freeze time, and an exception there aborts the function **before** `g_tRoundEnd` is created — so the round-end timer never starts and the round doesn't end on time.

The `sv_alltalk` lookup also re-ran `FindConVar()` on every `VoiceReset()` call rather than caching.

## Fix

Cache both in `CvarsInit()` next to the other game ConVars (`mp_autoteambalance`, `mp_limitteams`, `mp_restartgame`) and guard the uses:

- Missing `sv_alltalk` → treated as disabled, matching the engine default.
- Missing `mp_roundtime` → logs once via `LogError()` and skips the timer, rather than creating one with an undefined delay.

`LogError()` is used rather than ZR's `LogEvent()` because there is no `LogModule_RoundEnd` in the `LogModule` enum, and neither of these files logs today — adding an enum value plus its string mapping would be out of scope for this fix.

## Cross-check

`VAmbienceApplySky()` already handles this correctly a few files away:

```sourcepawn
// zr/visualeffects/visualambience.inc:241-245
ConVar hSkyname = FindConVar("sv_skyname");
if (hSkyname == null)
{
    return;
}
```

## How to reproduce the bug (to verify the fix)

Neither ConVar is missing on a stock CS:S/CS:GO server, so this is a robustness fix rather than one you hit by accident. To force it:

**Option A — remove the ConVar's provider.** `mp_roundtime` comes from the game DLL, so you can't unregister it directly. The realistic trigger is a non-standard mod/engine build, or CS2-era servers where the name changed (`mp_roundtime` vs `mp_roundtime_defuse`/`mp_roundtime_hostage` depending on mode). If your server only defines the mode-specific variants, an unpatched build throws on every freeze-time end.

**Option B — verify the guard directly.** Temporarily change the lookup in `CvarsInit()` to a name that certainly doesn't exist:

```sourcepawn
g_hRoundTime = FindConVar("mp_roundtime_does_not_exist");
```

Then rebuild and start a round.

- **Before** (with the same substitution applied to the old inline `FindConVar`): `logs/errors_*.log` shows an exception blamed on `RoundEndOnRoundFreezeEnd`, and the round runs past `mp_roundtime` without ZR ending it.
- **After:** one clean `[ZR] Can't find "mp_roundtime", round end timer not started.` line, no exception, and the rest of the round logic keeps working.

For `sv_alltalk`, the same substitution in `CvarsInit()` plus any action that calls `VoiceReset()` (round start, or `zr_config_reload`) shows the same before/after: exception vs. voice flags falling back to team-only.

## Version

Bumped to **3.13.9**.

> Note: one of 9 PRs from the review in #170; each bumps `ZR_VER_PATCH`. Patch numbers follow the merge order suggested there. Expect a trivial conflict on `hgversion.h.inc` if merged out of order. This PR also touches `cvars.inc`, as does #184 — adjacent but distinct lines.

## Testing

- Builds clean on `spcomp` 1.12.0 (no warnings), same include set as CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
