### PR TITLE
fix(weapons api): close the DataPack when a knockback retry timer is cancelled

### DIFF
--- a/src/addons/sourcemod/scripting/zr/api/weapons.api.inc
+++ b/src/addons/sourcemod/scripting/zr/api/weapons.api.inc
@@ -84,8 +84,10 @@ static void KBQ_CleanupJob(KnockbackJob job, Handle currentTimer = null, bool fr
         }
         else
         {
-            // Cancel a pending timer safely.
-            KillTimer(job.hTimer);
+            // Cancel a pending timer safely. autoClose closes the DataPack
+            // carried as timer data, which the callback would otherwise have
+            // been responsible for.
+            KillTimer(job.hTimer, true);
             job.hTimer = null;
         }
     }

--- a/src/addons/sourcemod/scripting/zr/hgversion.h.inc
+++ b/src/addons/sourcemod/scripting/zr/hgversion.h.inc
@@ -4,7 +4,7 @@
 #define ZR_VER_BRANCH           "master"
 #define ZR_VER_MAJOR            "3"
 #define ZR_VER_MINOR            "13"
-#define ZR_VER_PATCH            "3"
+#define ZR_VER_PATCH            "10"
 #define ZR_VERSION              ZR_VER_MAJOR..."."...ZR_VER_MINOR..."."...ZR_VER_PATCH
 #define ZR_VER_LICENSE          "GNU GPL, Version 3"
 #define ZR_VER_DATE             "Fri Sep 04 CEST 2026"


### PR DESCRIPTION
Closes #177. Part of #170.

## Problem

`KBQ_CreateRetryTimer()` attaches a `DataPack` as timer data, **without** `TIMER_DATA_HNDL_CLOSE` — so the callback owns the handle:

```sourcepawn
// zr/api/weapons.api.inc:94-101
DataPack pack = new DataPack();
pack.WriteString(job.weapon);
return CreateTimer(delay, KBQ_TimerRetrySetKB, pack, TIMER_FLAG_NO_MAPCHANGE);
```

That works on the normal path — `KBQ_TimerRetrySetKB()` does `delete pack` at line 156. But cancellation goes through a plain `KillTimer()`, which never runs the callback:

```sourcepawn
// zr/api/weapons.api.inc:85-90  (before)
// Cancel a pending timer safely.
KillTimer(job.hTimer);
job.hTimer = null;
```

The `DataPack` is orphaned. Nothing ever closes it.

`KB_QueueClearAll()` is called from `WeaponsOnMapEnd()` and walks **every** outstanding job, so a server with pending knockback jobs leaks one handle per job on **every map change**, accumulating for the lifetime of the server process.

## Fix

```sourcepawn
KillTimer(job.hTimer, true);
```

`autoClose` makes SourceMod close the data handle on the cancellation path, so every exit path is now covered. (The alternative — adding `TIMER_DATA_HNDL_CLOSE` at creation and dropping the manual `delete` — would work too, but touches both sites instead of one.)

## How to reproduce the bug (to verify the fix)

The retry queue only fills when `ZR_SetWeaponKnockback()` is called before the weapons backend is ready, so you need another plugin driving the API.

1. On a build **without** this patch, have a plugin call the ZR knockback native early — e.g. from its own `OnPluginStart()` / `OnMapStart()`, before ZR has parsed `weapons.txt`:

   ```sourcepawn
   ZR_SetWeaponKnockback("ak47", 3.0);
   ```

   Any weapon name works; calling it for several weapons makes the leak easier to see.

2. Confirm the jobs are pending — they retry with backoff (0.5s, 1s, 2s, 4s, 8s), so trigger a **map change within a few seconds** of the calls, while timers are still outstanding.

3. Compare handle counts across map changes:

   ```
   sm_dump_handles
   ```
   or watch the `DataPack` count in the output. On an unpatched build the count climbs by one per pending job per map change and never comes back down. On a patched build it stays flat.

   `sm profiler`-free alternative: run `sm_dump_handles` right after a few map changes and grep for `DataPack` — a steadily growing number of unowned packs attributed to `zombiereloaded.smx` is the symptom.

4. **After** the fix, the same sequence leaves the `DataPack` count stable across map changes.

If you don't have a plugin to drive the API, this one is easier to verify by reading the two code paths than by reproducing it live — the leak is unconditional on the cancellation branch.

## Version

Bumped to **3.13.10**.

> Note: one of 9 PRs from the review in #170; each bumps `ZR_VER_PATCH`. Patch numbers follow the merge order suggested there. Expect a trivial conflict on `hgversion.h.inc` if merged out of order.

## Testing

- Builds clean on `spcomp` 1.12.0 (no warnings), same include set as CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
