### PR TITLE
fix(zmarket): guard the purchase-count trie and the deferred buy refund

### DIFF
--- a/src/addons/sourcemod/scripting/zr/hgversion.h.inc
+++ b/src/addons/sourcemod/scripting/zr/hgversion.h.inc
@@ -4,7 +4,7 @@
 #define ZR_VER_BRANCH           "master"
 #define ZR_VER_MAJOR            "3"
 #define ZR_VER_MINOR            "13"
-#define ZR_VER_PATCH            "3"
+#define ZR_VER_PATCH            "11"
 #define ZR_VERSION              ZR_VER_MAJOR..."."...ZR_VER_MINOR..."."...ZR_VER_PATCH
 #define ZR_VER_LICENSE          "GNU GPL, Version 3"
 #define ZR_VER_DATE             "Fri Sep 04 CEST 2026"

--- a/src/addons/sourcemod/scripting/zr/weapons/zmarket.inc
+++ b/src/addons/sourcemod/scripting/zr/weapons/zmarket.inc
@@ -290,6 +290,13 @@ void ZMarketResetPurchaseCount(int client)
  */
 void ZMarketSetPurchaseCount(int client, const char[] weapon, int value, bool add = false)
 {
+    // The trie is destroyed on disconnect, so a deferred caller can land here
+    // with nothing to write to.
+    if (g_hZMarketPurchaseCount[client] == null)
+    {
+        return;
+    }
+
     // Initialize variable (value is 0)
     int purchasemax;
 
@@ -314,6 +321,14 @@ int ZMarketGetPurchaseCount(int client, const char[] weapon)
 {
     // Get value in client's trie.
     int value;
+
+    // The trie is destroyed on disconnect, so a deferred caller can land here
+    // with nothing to read from.
+    if (g_hZMarketPurchaseCount[client] == null)
+    {
+        return 0;
+    }
+
     g_hZMarketPurchaseCount[client].GetValue(weapon, value);
     return value;
 }
@@ -962,7 +977,13 @@ void DelayedBuyRefund(DataPack hPack)
     int iDefaultCash = hPack.ReadCell();
     delete hPack;
 
+    // The player may have left between the buy and this frame.
     int client = GetClientOfUserId(userid);
+    if (!ZRIsClientValid(client))
+    {
+        return;
+    }
+
     AccountSetClientCash(client, iDefaultCash);
 }
 


### PR DESCRIPTION
Closes #178. Part of #170.

Two related lifetime holes in ZMarket, both reachable when a client disconnects at the wrong moment.

## 1. Null `StringMap` dereference

The per-client purchase-count trie is destroyed on disconnect, leaving the slot `null`:

```sourcepawn
// zr/weapons/zmarket.inc:222-227
void ZMarketOnClientDisconnect(int client)
{
    delete g_hZMarketPurchaseCount[client];
}
```

`ZMarketResetPurchaseCount()` checks for that — but the two accessors right below it did not:

```sourcepawn
// before
g_hZMarketPurchaseCount[client].SetValue(weapon, purchasemax + value);   // :303
g_hZMarketPurchaseCount[client].GetValue(weapon, value);                 // :317
```

Either raises `Invalid handle` for any deferred caller that runs after the client left.

## 2. Unvalidated client in the deferred buy refund

```sourcepawn
// zr/weapons/zmarket.inc:958-967  (before)
int client = GetClientOfUserId(userid);
AccountSetClientCash(client, iDefaultCash);
```

Storing a userid in the `DataPack` is the right call, but the lookup result was never checked. A player who buys and disconnects within the same frame yields `client == 0`, and `AccountSetClientCash(0, ...)` runs on an invalid index.

This is also the concrete path that can trigger problem 1.

## Fix

- Null-guard `ZMarketSetPurchaseCount()` and `ZMarketGetPurchaseCount()`, matching the existing guard in `ZMarketResetPurchaseCount()`. The getter returns `0`, which is what an empty trie would have yielded anyway.
- Validate with `ZRIsClientValid()` in `DelayedBuyRefund()` before touching the client.

## How to reproduce the bug (to verify the fix)

Both need a disconnect inside a one-frame window, so the reliable way is to force it rather than wait for it.

**Setup:**
```
sm_cvar zr_weapons_zmarket_freespawn 1
```

**Repro:**

1. On a build **without** this patch, join as a human before the mother zombie spawns.
2. Bind the two actions to fire back to back so the disconnect lands in the same frame as the buy:
   ```
   bind p "buy ak47; disconnect"
   ```
   Press `p`.
3. Check `logs/errors_*.log`:

   **Before:** an exception blamed on `zombiereloaded.smx`, at `DelayedBuyRefund` — `Client index 0 is invalid` from `AccountSetClientCash`. If the purchase-count path is also hit you may see a second `Invalid handle` entry from `ZMarketSetPurchaseCount`.

   **After:** no entries. The refund is simply skipped for the departed player, which is the correct behaviour.

A less fiddly variant that exercises the same window: with several bots buying (`sm_cvar bot_quota 10`, free-spawn on), run `sm_cvar bot_quota 0` mid-buy-phase. Bot removal during the buy round hits the same deferred path.

For the purchase-count guards specifically, the rebuy path (`zr_weapons_zmarket_rebuy`) on a client whose cookies finish loading right as they disconnect exercises `ZMarketGetPurchaseCount()` with a destroyed trie.

## Version

Bumped to **3.13.11**.

> Note: one of 9 PRs from the review in #170; each bumps `ZR_VER_PATCH`. Patch numbers follow the merge order suggested there. Expect a trivial conflict on `hgversion.h.inc` if merged out of order. This PR also touches `zmarket.inc`, as does #184 — different functions, but `CommandPlayerBuy`/`DelayedBuyRefund` sit close together, so a small conflict is possible depending on merge order.

## Testing

- Builds clean on `spcomp` 1.12.0 (no warnings), same include set as CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
