### PR TITLE
fix(timers): carry a userid instead of a client index

### DIFF
--- a/src/addons/sourcemod/scripting/zr/antistick.inc
+++ b/src/addons/sourcemod/scripting/zr/antistick.inc
@@ -163,7 +163,7 @@ public void AntiStickStartTouch(int client, int entity)
     {
         // Disable collisions to unstick, and start timers to re-solidify.
         AntiStickSetCollisionGroup(client, ANTISTICK_COLLISIONS_OFF);
-        CreateTimer(0.0, AntiStickSolidifyTimer, client, TIMER_FLAG_NO_MAPCHANGE | TIMER_REPEAT);
+        CreateTimer(0.0, AntiStickSolidifyTimer, GetClientUserId(client), TIMER_FLAG_NO_MAPCHANGE | TIMER_REPEAT);
     }
 }
 
@@ -172,10 +172,15 @@ public void AntiStickStartTouch(int client, int entity)
  *
  * @param client        The client index.
  */
-public Action AntiStickSolidifyTimer(Handle timer, any client)
+public Action AntiStickSolidifyTimer(Handle timer, any userid)
 {
+    // Resolve the userid now. This timer repeats and its handle isn't stored,
+    // so it can't be killed on disconnect - without this it would keep running
+    // against whoever inherits the slot.
+    int client = GetClientOfUserId(userid);
+
     // If client has left, then stop.
-    if (!IsClientInGame(client))
+    if (!ZRIsClientValid(client) || !IsClientInGame(client))
     {
         return Plugin_Stop;
     }

--- a/src/addons/sourcemod/scripting/zr/event.inc
+++ b/src/addons/sourcemod/scripting/zr/event.inc
@@ -171,7 +171,7 @@ public Action EventPlayerTeam(Event event, const char[] name, bool dontBroadcast
 
     // Fire post joinclass command. (Bots dont joinclass, so we fire it from here instead.)
     if (IsFakeClient(index) && !IsClientSourceTV(index))
-        CreateTimer(0.1, CommandPlayerClassPost, index);
+        CreateTimer(0.1, CommandPlayerClassPost, event.GetInt("userid"));
 
     return Plugin_Handled;
 }
@@ -214,7 +214,7 @@ public Action EventPlayerSpawn(Event event, const char[] name, bool dontBroadcas
     ImmunityClientSpawn(index);
 
     // Fire post player_spawn event.
-    CreateTimer(0.1, EventPlayerSpawnPost, index);
+    CreateTimer(0.1, EventPlayerSpawnPost, event.GetInt("userid"));
     return Plugin_Continue;
 }
 
@@ -226,8 +226,12 @@ public Action EventPlayerSpawn(Event event, const char[] name, bool dontBroadcas
  * @param name      Name of the event.
  * @dontBroadcast   If true, event is broadcasted to all clients, false if not.
  */
-public Action EventPlayerSpawnPost(Handle timer, any client)
+public Action EventPlayerSpawnPost(Handle timer, any userid)
 {
+    // Resolve the userid now: the slot may hold a different player by the time
+    // this fires.
+    int client = GetClientOfUserId(userid);
+
     // If client isn't in-game, then stop.
     if (client <= 0 || client > MaxClients || !IsClientConnected(client) || !IsClientInGame(client))
     {
@@ -302,18 +306,9 @@ public Action EventPlayerDeath(Event event, const char[] name, bool dontBroadcas
  */
 public Action EventPlayerJump(Event event, const char[] name, bool dontBroadcast)
 {
-    // Get all required event info.
-    int index = GetClientOfUserId(event.GetInt("userid"));
-
-    // The userid may no longer map to a client. Client index 0 is invalid for
-    // the client natives used in the post callback.
-    if (!ZRIsClientValid(index))
-    {
-        return Plugin_Continue;
-    }
-
-    // Fire post player_jump event.
-    CreateTimer(0.0, EventPlayerJumpPost, index);
+    // Fire post player_jump event. The userid is resolved in the callback, so
+    // a slot reused by another player can't be mistaken for the jumper.
+    CreateTimer(0.0, EventPlayerJumpPost, event.GetInt("userid"));
     return Plugin_Continue;
 }
 
@@ -325,10 +320,14 @@ public Action EventPlayerJump(Event event, const char[] name, bool dontBroadcast
  * @param name      Name of the event.
  * @dontBroadcast   If true, event is broadcasted to all clients, false if not.
  */
-public Action EventPlayerJumpPost(Handle timer, any client)
+public Action EventPlayerJumpPost(Handle timer, any userid)
 {
+    // Resolve the userid now: the slot may hold a different player by the time
+    // this fires.
+    int client = GetClientOfUserId(userid);
+
     // If client isn't in-game, then stop.
-    if (!IsClientInGame(client))
+    if (!ZRIsClientValid(client) || !IsClientInGame(client))
     {
         return Plugin_Continue;
     }
@@ -349,7 +348,7 @@ public Action EventPlayerJumpPost(Handle timer, any client)
 public Action CommandPlayerClass(int client, const char[] command, int argc)
 {
     // Fire post joinclass command.
-    CreateTimer(0.1, CommandPlayerClassPost, client);
+    CreateTimer(0.1, CommandPlayerClassPost, GetClientUserId(client));
     return Plugin_Continue;
 }
 
@@ -361,10 +360,14 @@ public Action CommandPlayerClass(int client, const char[] command, int argc)
  * @param command   The command performed.
  * @param argc      The amount of arguments.
  */
-public Action CommandPlayerClassPost(Handle timer, any client)
+public Action CommandPlayerClassPost(Handle timer, any userid)
 {
+    // Resolve the userid now: the slot may hold a different player by the time
+    // this fires.
+    int client = GetClientOfUserId(userid);
+
     // If client isn't in-game, then stop.
-    if (!IsClientInGame(client))
+    if (!ZRIsClientValid(client) || !IsClientInGame(client))
     {
         return Plugin_Continue;
     }

--- a/src/addons/sourcemod/scripting/zr/hgversion.h.inc
+++ b/src/addons/sourcemod/scripting/zr/hgversion.h.inc
@@ -4,7 +4,7 @@
 #define ZR_VER_BRANCH           "master"
 #define ZR_VER_MAJOR            "3"
 #define ZR_VER_MINOR            "13"
-#define ZR_VER_PATCH            "11"
+#define ZR_VER_PATCH            "12"
 #define ZR_VERSION              ZR_VER_MAJOR..."."...ZR_VER_MINOR..."."...ZR_VER_PATCH
 #define ZR_VER_LICENSE          "GNU GPL, Version 3"
 #define ZR_VER_DATE             "Fri Sep 04 CEST 2026"

--- a/src/addons/sourcemod/scripting/zr/playerclasses/classevents.inc
+++ b/src/addons/sourcemod/scripting/zr/playerclasses/classevents.inc
@@ -305,7 +305,7 @@ void ClassOnClientSpawn(int client)
         ClassAllowInstantChange[client] = true;
 
         // Create timer to disable instant change.
-        CreateTimer(instantspawn, Event_ClassDisableInstantSpawn, client, TIMER_FLAG_NO_MAPCHANGE);
+        CreateTimer(instantspawn, Event_ClassDisableInstantSpawn, GetClientUserId(client), TIMER_FLAG_NO_MAPCHANGE);
     }
     else
     {
@@ -483,8 +483,16 @@ void ClassOnClientInfected(int client, bool motherzombie = false) //responsavel 
 /**
  * Timer callback for disabling instant class change setting on a client.
  */
-public Action Event_ClassDisableInstantSpawn(Handle timer, any client)
+public Action Event_ClassDisableInstantSpawn(Handle timer, any userid)
 {
+    // Resolve the userid now: this delay is operator-configurable, so the slot
+    // can easily hold a different player by the time it fires.
+    int client = GetClientOfUserId(userid);
+    if (!ZRIsClientValid(client))
+    {
+        return Plugin_Continue;
+    }
+
     // Disable instant class change.
     ClassAllowInstantChange[client] = false;
     return Plugin_Continue;


### PR DESCRIPTION
Closes #179. Part of #170.

## Problem

A client index is only meaningful for as long as that player occupies the slot. When they disconnect and a new player connects into the same slot before the timer fires, the callback silently acts on **the wrong player** — no error, no log line, just the wrong person getting the effect.

Most per-client timers in this plugin are stored in an array and killed on disconnect, which papers over the problem. These six were fire-and-forget:

| Site | Callback | Delay |
| ---- | -------- | ----- |
| `event.inc:165` | `CommandPlayerClassPost` | 0.1s |
| `event.inc:208` | `EventPlayerSpawnPost` | 0.1s |
| `event.inc:300` | `EventPlayerJumpPost` | 0.0s |
| `event.inc:336` | `CommandPlayerClassPost` | 0.1s |
| `classevents.inc:308` | `Event_ClassDisableInstantSpawn` | `zr_classes_change_timelimit` |
| `antistick.inc:166` | `AntiStickSolidifyTimer` | 0.0s, `TIMER_REPEAT` |

Two are worse than the generic case:

- **`Event_ClassDisableInstantSpawn`** — the delay is operator-configurable, so it can be seconds long. It flips `ClassAllowInstantChange[client]`, so a reused slot gets its instant-class-change permission revoked out of nowhere.
- **`AntiStickSolidifyTimer`** — a **repeating** timer whose handle is never stored, so it cannot be killed on disconnect. It relies entirely on its own `Plugin_Stop` conditions, which a newly-connected player in that slot will not satisfy — so it keeps running and manipulating that player's collision group.

## Fix

Event handlers now pass `event.GetInt("userid")` straight through instead of resolving to an index and back, and each callback resolves the userid itself and validates before use.

```sourcepawn
// before
CreateTimer(0.1, EventPlayerSpawnPost, index);

public Action EventPlayerSpawnPost(Handle timer, any client)
{
    if (client <= 0 || ... ) return Plugin_Continue;

// after
CreateTimer(0.1, EventPlayerSpawnPost, event.GetInt("userid"));

public Action EventPlayerSpawnPost(Handle timer, any userid)
{
    int client = GetClientOfUserId(userid);
    if (client <= 0 || ... ) return Plugin_Continue;
```

### Side effect worth noting

This also removes the unvalidated `GetClientOfUserId()` in `EventPlayerJump()` — the index isn't computed there at all any more. That's the `player_jump` half of #173, fixed here as a consequence rather than deliberately. #183 handles the `player_team` half; if both land, expect a small conflict in `EventPlayerJump()` where #183 adds a guard this PR deletes the need for.

## How to reproduce the bug (to verify the fix)

Slot reuse is the mechanism, so you need a disconnect followed by a connect into the same slot inside the timer's window. `AntiStickSolidifyTimer` is the easiest to observe because it repeats.

**Antistick (most visible):**

1. On a build **without** this patch, get two players genuinely stuck inside each other so antistick fires — the simplest way is `sm_cvar zr_antistick 1`, then have two zombies pile onto a human in a doorway. `zr_log_module_antistick 1` plus `zr_log 1` will print `Player "X" and "Y" are intersecting. Removing collisions.` so you can confirm the timer started.
2. Immediately after that log line, have the stuck player **disconnect**, and have another player connect into the freed slot (on a full-ish server this happens by itself; otherwise `bot_add` right after the disconnect claims the low slot).
3. Watch the newcomer: on an unpatched build their collision group gets forced to `ANTISTICK_COLLISIONS_ON` by the inherited timer, and the debug log prints `Player "<newcomer>" is no longer intersecting anyone.` — a player who was never stuck.
4. **After:** the timer stops on the first tick after the original player leaves (`GetClientOfUserId` returns 0), and the newcomer is untouched.

**Instant class change (longest window, easiest to time):**

1. `sm_cvar zr_classes_change_timelimit 30` — gives you a 30-second window to work with.
2. A player spawns (timer armed for 30s), then disconnects a few seconds later.
3. Another player connects into that slot within the window and tries `!zclass` to change class instantly.
4. **Before:** their instant-change permission is revoked partway through, seemingly at random, when the inherited timer fires. **After:** unaffected.

The `event.inc` ones share the same mechanism but with 0.0–0.1s windows, so they need a disconnect landing in that exact frame — impractical to force by hand, and best verified by reading the diff.

## Version

Bumped to **3.13.12**.

> Note: the last of 9 PRs from the review in #170; each bumps `ZR_VER_PATCH`. Patch numbers follow the merge order suggested there. Expect a trivial conflict on `hgversion.h.inc` if merged out of order, plus the `EventPlayerJump()` overlap with #183 described above.

## Testing

- Builds clean on `spcomp` 1.12.0 (no warnings), same include set as CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
