### PR TITLE
fix(classes): capture the original player model only once per connection

### DIFF
--- a/src/addons/sourcemod/scripting/zr/hgversion.h.inc
+++ b/src/addons/sourcemod/scripting/zr/hgversion.h.inc
@@ -4,7 +4,7 @@
 #define ZR_VER_BRANCH           "master"
 #define ZR_VER_MAJOR            "3"
 #define ZR_VER_MINOR            "13"
-#define ZR_VER_PATCH            "12"
+#define ZR_VER_PATCH            "13"
 #define ZR_VERSION              ZR_VER_MAJOR..."."...ZR_VER_MINOR..."."...ZR_VER_PATCH
 #define ZR_VER_LICENSE          "GNU GPL, Version 3"
 #define ZR_VER_DATE             "Fri Sep 04 CEST 2026"

--- a/src/addons/sourcemod/scripting/zr/playerclasses/apply.inc
+++ b/src/addons/sourcemod/scripting/zr/playerclasses/apply.inc
@@ -150,6 +150,14 @@ bool ClassApplyModel(int client, int classindex, int cachetype = ZR_CLASS_CACHE_
     }
     else if (strcmp(modelpath, "default", false) == 0)
     {
+        // No original model captured yet (client hasn't had its first spawn).
+        // Leave the current model alone rather than restoring an empty or stale
+        // path.
+        if (!ClassOriginalPlayerModel[client][0])
+        {
+            return true;
+        }
+
         // Get current model.
         GetClientModel(client, modelpath, sizeof(modelpath));
 

--- a/src/addons/sourcemod/scripting/zr/playerclasses/classevents.inc
+++ b/src/addons/sourcemod/scripting/zr/playerclasses/classevents.inc
@@ -131,8 +131,11 @@ void ClassClientInit(int client)
     // Reset spawn flag.
     ClassPlayerSpawned[client] = false;
 
-    // The original model is captured on the client's first spawn.
+    // The original model is captured on the client's first spawn. Clear the
+    // stored path too, so a slot reused by a new occupant can't hand the
+    // previous player's model to a "default" restore before that capture runs.
     ClassOriginalPlayerModelCached[client] = false;
+    ClassOriginalPlayerModel[client][0] = 0;
 }
 
 /**

--- a/src/addons/sourcemod/scripting/zr/playerclasses/classevents.inc
+++ b/src/addons/sourcemod/scripting/zr/playerclasses/classevents.inc
@@ -130,6 +130,9 @@ void ClassClientInit(int client)
 
     // Reset spawn flag.
     ClassPlayerSpawned[client] = false;
+
+    // The original model is captured on the client's first spawn.
+    ClassOriginalPlayerModelCached[client] = false;
 }
 
 /**
@@ -228,9 +231,17 @@ void ClassOnClientSpawn(int client)
     // Restore class indexes to be selected on spawn, if available.
     ClassRestoreNextIndexes(client);
 
-    // Cache original player model.
-    GetClientModel(client, originalmodel, sizeof(originalmodel));
-    strcopy(ClassOriginalPlayerModel[client], PLATFORM_MAX_PATH, originalmodel);
+    // Cache the original player model, once per connection. Re-reading it on
+    // every spawn is unsafe: right after CS_RespawnPlayer() (zr_respawn +
+    // zr_respawn_team_zombie) the player can still be carrying the zombie model
+    // this module applied last life, and caching that would later restore a
+    // zombie skin onto a human through a class whose model is "default".
+    if (!ClassOriginalPlayerModelCached[client])
+    {
+        GetClientModel(client, originalmodel, sizeof(originalmodel));
+        strcopy(ClassOriginalPlayerModel[client], PLATFORM_MAX_PATH, originalmodel);
+        ClassOriginalPlayerModelCached[client] = true;
+    }
 
     // Check if the player should spawn in admin mode.
     if (ClassPlayerInAdminMode[client])

--- a/src/addons/sourcemod/scripting/zr/playerclasses/playerclasses.inc
+++ b/src/addons/sourcemod/scripting/zr/playerclasses/playerclasses.inc
@@ -493,6 +493,12 @@ bool ClassAllowInstantChange[MAXPLAYERS + 1];
 char ClassOriginalPlayerModel[MAXPLAYERS + 1][PLATFORM_MAX_PATH];
 
 /**
+ * Whether ClassOriginalPlayerModel has been captured for this client. Captured
+ * once per connection so a later "default" restore can't pick up a class model.
+ */
+bool ClassOriginalPlayerModelCached[MAXPLAYERS + 1];
+
+/**
  * Specifies whether a player has spawned.
  */
 bool ClassPlayerSpawned[MAXPLAYERS + 1];


### PR DESCRIPTION
Refs #165 (the `ClassOriginalPlayerModel` half of it).

## Problem

`ClassOnClientSpawn()` re-reads `GetClientModel()` into `ClassOriginalPlayerModel[client]` on **every** spawn:

```sourcepawn
// zr/playerclasses/classevents.inc  (before)
// Cache original player model.
GetClientModel(client, originalmodel, sizeof(originalmodel));
strcopy(ClassOriginalPlayerModel[client], PLATFORM_MAX_PATH, originalmodel);
```

That value is only ever meant to be *the model the player would have without ZR*. The `"default"` branch in `ClassApplyModel()` restores it verbatim:

```sourcepawn
// zr/playerclasses/apply.inc:151-165
else if (strcmp(modelpath, "default", false) == 0)
{
    GetClientModel(client, modelpath, sizeof(modelpath));
    if (strcmp(ClassOriginalPlayerModel[client], modelpath) != 0)
    {
        strcopy(modelpath, sizeof(modelpath), ClassOriginalPlayerModel[client]);
    }
    ...
}
```

On a zombie respawn (`zr_respawn 1` + `zr_respawn_team_zombie 1`), the `player_spawn` that fires from `CS_RespawnPlayer()` runs **before** the model has settled back to the team default — ZR itself works around this by applying class models in the 0.1 s-delayed `ClassOnClientSpawnPost`, not in the synchronous event. So the zombie model this plugin applied last life can still be on the player when `ClassOnClientSpawn` reads it, and it gets stored as the "original". A later human class whose model is `"default"` then restores that zombie skin onto a human.

This is the secondary cause noted in #165 (the primary one — `ClassApplyModel()` bailing when a model isn't precached — is addressed by the merged #180 for long paths, and by the still-open #168 for genuinely-unprecached models).

## Fix

Capture `ClassOriginalPlayerModel` **once**, on the client's first spawn. At that point ZR has not applied any class model yet (models go through the delayed post callback), so the synchronous read is always the pre-ZR team default. A `ClassOriginalPlayerModelCached[client]` flag guards it, reset in `ClassClientInit()` (`OnClientPutInServer`) so each new occupant of a slot re-captures.

"Once per connection" also matches the intended semantics of `"default"` — *the model the player joined with* — better than a per-spawn re-read that races the engine.

## How to reproduce the bug (to verify the fix)

You need a human class configured with `"model" "default"` (several stock configs ship one), plus respawn:

```
sm_cvar zr_respawn 1
sm_cvar zr_respawn_delay 3
sm_cvar zr_respawn_team_zombie 1
```

1. Start a round, get infected (or be a mother zombie). You now have a zombie model.
2. Die as a zombie. After `zr_respawn_delay` you respawn — still a zombie, still the zombie model. This respawn is the one that poisons the cache.
3. Let the round end and start the next round as a **human**, on a class whose model is `"default"`.
4. **Before this patch:** you spawn as a human (human HP, no knockback, CT team) but rendered with the **zombie model** from step 1–2. It clears if you change class to one with an explicit model, or on a clean round where the poisoning respawn didn't happen — hence "sometimes".
5. **After this patch:** the human `"default"` class restores the model you connected with; the zombie respawn no longer overwrites the cache.

Quicker partial check: add a temporary `LogMessage("orig model for %N = %s", client, ClassOriginalPlayerModel[client])` right after the capture. On an unpatched build you'll see it change to a `models/player/z*/…` path after a zombie respawn; on a patched build it stays at the team default for the whole connection.

## Not covered here

The "model not precached at all" cases from #165 (model added to `models.txt` mid-map, `zr_config_reload models`, class pointing at a path absent from `models.txt`) are still tracked by #168. #165 should stay open until that lands or the reporter confirms the merged fixes are enough.

## Version

Bumped to **3.13.13**.

## Testing

- Builds clean on `spcomp` 1.12.0 (no warnings), same include set as CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
