### PR TITLE
ci: check out the repo in the tag job so 'latest' can be created

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,7 @@
 name: CI
 on: [push, pull_request, workflow_dispatch]
+permissions:
+  contents: write
 jobs:
   build:
     name: Build
@@ -46,6 +48,10 @@ jobs:
     if: github.ref == 'refs/heads/master' || github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+          fetch-tags: true
       - name: Delete existing "latest" release and tag
         run: |
           set -euo pipefail
@@ -55,6 +61,7 @@ jobs:
       - uses: rickstaa/action-create-tag@v1
         with:
           tag: latest
+          force_push_tag: true
           github_token: ${{ secrets.GITHUB_TOKEN }}
   release:
     name: Release


### PR DESCRIPTION
Closes #190.

## Problem

The `Tag` job has failed on **every** push to `master` since #159, and `Release` is skipped as a result (`needs: [build, tag]`). The `latest` tag and its release have not moved since.

```
[action-create-tag] Create tag 'latest'.
fatal: not a git repository (or any parent up to mount point /github)
```

`rickstaa/action-create-tag@v1` is a Docker action that shells out to `git` inside `/github/workspace`. #159 ("build plugins with setup-sp instead of sourceknight") dropped the `- uses: actions/checkout@v7` step from the `tag` job; at the time the first step was still `dev-drprasad/delete-tag-and-release` (an API action that needs no working tree), so only the tag-creation step broke. #161 swapped the delete step for `gh release delete` but didn't restore the checkout.

## Change

```diff
 name: CI
 on: [push, pull_request, workflow_dispatch]
+permissions:
+  contents: write
 jobs:
@@ tag job @@
     steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+          fetch-tags: true
       - name: Delete existing "latest" release and tag
         run: |
           set -euo pipefail
           gh release delete latest --cleanup-tag --yes || true
       - uses: rickstaa/action-create-tag@v1
         with:
           tag: latest
+          force_push_tag: true
           github_token: ${{ secrets.GITHUB_TOKEN }}
```

- **checkout** with `fetch-depth: 0` + `fetch-tags: true` so the action has a repo and the existing tag refs.
- **`force_push_tag: true`** — `latest` is a moving tag; without it the action trips `tag_exists_error` on the run right after the tag reappears.
- **`permissions: contents: write`** at the top level, explicit, for the tag push and the release upload in the `release` job.

The `release` job is left as-is — it only consumes the build artifact and `svenstaro/upload-release-action@v2`, no working tree needed.

## Testing

`tag` and `release` are gated on `github.ref == 'refs/heads/master'`, so they do **not** run on this PR — only the `build` job does. Full verification happens on the first push to `master` after merge: `Tag` should go green and `Release` should publish `latest` again.

YAML validated locally (`yaml.safe_load`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
