### PR TITLE
ci(docs): comment the generated-reference diff on pull requests

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -54,6 +54,9 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      # A PR conversation comment is an "issue comment", but the REST endpoint
+      # accepts "Pull requests: write" when the issue is a pull request - which
+      # is all this job ever touches. No issues: write needed.
       pull-requests: write
     steps:
       - uses: actions/checkout@v7
@@ -82,24 +85,25 @@ jobs:
           report="$RUNNER_TEMP/report.md"
           : > "$report"
           changed=0
+          max_lines=200
           names=$(ls "$RUNNER_TEMP/head" "$RUNNER_TEMP/base-ref" 2>/dev/null | { grep '\.md$' || true; } | sort -u)
           for name in $names; do
-            base="$RUNNER_TEMP/base-ref/$name"
-            head="$RUNNER_TEMP/head/$name"
-            [ -f "$base" ] || base=/dev/null
-            [ -f "$head" ] || head=/dev/null
+            old="$RUNNER_TEMP/base-ref/$name"; [ -f "$old" ] || old=/dev/null
+            new="$RUNNER_TEMP/head/$name";     [ -f "$new" ] || new=/dev/null
             # Ignore the "Auto-generated ... on <timestamp>" line, it always changes.
-            if diff -I '^    Auto-generated ' "$base" "$head" >/dev/null 2>&1; then
+            if diff -I '^    Auto-generated ' "$old" "$new" >/dev/null 2>&1; then
               continue
             fi
             changed=1
-            diff -u -I '^    Auto-generated ' "$base" "$head" > "$RUNNER_TEMP/d.txt" 2>&1 || true
+            # Unified diff without the 2-line "--- / +++" file header.
+            diff -u -I '^    Auto-generated ' "$old" "$new" 2>&1 | tail -n +3 > "$RUNNER_TEMP/d.txt" || true
+            total=$(wc -l < "$RUNNER_TEMP/d.txt")
             {
               echo "<details><summary><code>docs-site/docs/reference/$name</code></summary>"
               echo
               echo '```diff'
-              sed -n '3,203p' "$RUNNER_TEMP/d.txt"
-              if [ "$(wc -l < "$RUNNER_TEMP/d.txt")" -gt 203 ]; then echo '... diff truncated'; fi
+              head -n "$max_lines" "$RUNNER_TEMP/d.txt"
+              if [ "$total" -gt "$max_lines" ]; then echo "... $((total - max_lines)) more diff line(s) truncated"; fi
               echo '```'
               echo
               echo "</details>"

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -45,6 +45,105 @@ jobs:
         with:
           path: site
 
+  reference-diff:
+    name: Comment reference diff
+    # Same-repo PRs only - forked PRs get a read-only token and cannot comment.
+    if: >-
+      github.event_name == 'pull_request' &&
+      github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Generate the reference for the PR head and its base
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: |
+          set -euo pipefail
+          # Both runs use *this branch's* generator so the diff reflects source /
+          # config changes only; a generator-logic change shows up in the PR diff.
+          python docs-site/gen/generate_reference.py --out "$RUNNER_TEMP/head"
+          git worktree add --detach "$RUNNER_TEMP/base" "$BASE_SHA"
+          python docs-site/gen/generate_reference.py --repo-root "$RUNNER_TEMP/base" --out "$RUNNER_TEMP/base-ref"
+
+      - name: Diff the generated reference
+        id: diff
+        run: |
+          set -euo pipefail
+          report="$RUNNER_TEMP/report.md"
+          : > "$report"
+          changed=0
+          names=$(ls "$RUNNER_TEMP/head" "$RUNNER_TEMP/base-ref" 2>/dev/null | { grep '\.md$' || true; } | sort -u)
+          for name in $names; do
+            base="$RUNNER_TEMP/base-ref/$name"
+            head="$RUNNER_TEMP/head/$name"
+            [ -f "$base" ] || base=/dev/null
+            [ -f "$head" ] || head=/dev/null
+            # Ignore the "Auto-generated ... on <timestamp>" line, it always changes.
+            if diff -I '^    Auto-generated ' "$base" "$head" >/dev/null 2>&1; then
+              continue
+            fi
+            changed=1
+            diff -u -I '^    Auto-generated ' "$base" "$head" > "$RUNNER_TEMP/d.txt" 2>&1 || true
+            {
+              echo "<details><summary><code>docs-site/docs/reference/$name</code></summary>"
+              echo
+              echo '```diff'
+              sed -n '3,203p' "$RUNNER_TEMP/d.txt"
+              if [ "$(wc -l < "$RUNNER_TEMP/d.txt")" -gt 203 ]; then echo '... diff truncated'; fi
+              echo '```'
+              echo
+              echo "</details>"
+              echo
+            } >> "$report"
+          done
+          echo "changed=$changed" >> "$GITHUB_OUTPUT"
+
+      - name: Upsert the PR comment
+        uses: actions/github-script@v7
+        env:
+          CHANGED: ${{ steps.diff.outputs.changed }}
+        with:
+          script: |
+            const fs = require('fs');
+            const marker = '<!-- docs-reference-diff -->';
+            const { owner, repo } = context.repo;
+            const issue_number = context.issue.number;
+
+            const existing = (await github.paginate(github.rest.issues.listComments, {
+              owner, repo, issue_number,
+            })).find(c => c.body && c.body.includes(marker));
+
+            if (process.env.CHANGED !== '1') {
+              // Reference is back in sync - retract a previous preview, if any.
+              if (existing) {
+                await github.rest.issues.updateComment({
+                  owner, repo, comment_id: existing.id,
+                  body: `${marker}\n### 📖 Generated reference\n\nThis PR no longer changes the generated \`docs-site/docs/reference/\` output.`,
+                });
+              }
+              return;
+            }
+
+            const body = `${marker}\n### 📖 Generated reference changed\n\n`
+              + `This PR changes what \`docs-site/gen/generate_reference.py\` produces. `
+              + `These files are git-ignored and rebuilt on deploy - this is just a preview.\n\n`
+              + fs.readFileSync(`${process.env.RUNNER_TEMP}/report.md`, 'utf8');
+            if (existing) {
+              await github.rest.issues.updateComment({ owner, repo, comment_id: existing.id, body });
+            } else {
+              await github.rest.issues.createComment({ owner, repo, issue_number, body });
+            }
+
   deploy:
     name: Deploy to GitHub Pages
     if: github.event_name != 'pull_request' && (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/main')

--- a/docs-site/README.md
+++ b/docs-site/README.md
@@ -48,3 +48,8 @@ resolved via their `#define`. The CI job runs it on every push to `master`, so
 any cvar or command change ships with matching docs automatically. The job
 fails if zero cvars or zero commands are parsed, which catches an accidental
 change to the declaration style.
+
+On a pull request the `reference-diff` job regenerates the reference for the PR
+and its base branch and posts (or updates) a single comment with a `diff` of
+what changed, so a cvar/command rename or default change is visible in review
+without checking out the branch.


### PR DESCRIPTION
## What

Adds a `reference-diff` job to `.github/workflows/docs.yml`. On a
`pull_request` it:

1. Regenerates `docs-site/docs/reference/*.md` for the **PR head**.
2. Adds a detached worktree at the PR **base** SHA and regenerates the
   reference there too (using this branch's generator for both, so the diff
   reflects source/config changes — a generator-logic change is already
   visible in the PR's own file diff).
3. Posts (or updates) **one** sticky comment with a `diff` block per reference
   file that changed.

So a cvar/command rename, a changed default, or a newly-shipped class shows up
in review without checking out the branch.

## Details

- **Same-repo PRs only** (`head.repo.full_name == github.repository`) — a
  forked PR gets a read-only `GITHUB_TOKEN` and cannot comment.
- The `Auto-generated … on <timestamp>` line is filtered (`diff -I`), so a
  plain rebuild with no real change produces no comment.
- The file list is discovered from the generator output, not hard-coded, so it
  keeps working if `generate_reference.py` gains or drops a page.
- Each file's diff is capped at 200 lines with a "diff truncated" marker.
- If a later push brings the reference back in sync, the existing comment is
  rewritten to say so.
- Job scoped to `contents: read` + `pull-requests: write`; `build` / `deploy`
  jobs unchanged.

## Testing

`python -c "import yaml; yaml.safe_load(open('.github/workflows/docs.yml'))"` is
clean, and the diff/report shell block was run locally against a mutated copy of
the generated reference (content change shown, timestamp-only change ignored,
`changed` output correct). Full end-to-end runs on this PR.

Follow-up from #169 ("PR CI comment when the generated cvar list changes").

🤖 Generated with [Claude Code](https://claude.com/claude-code)