### PR TITLE
ci(docs): fix failing GitHub Pages deployment after the Dependabot merges

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -60,5 +60,17 @@ jobs:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
+      # Force the "GitHub Actions" build type so a leftover "Deploy from a branch"
+      # source can't trigger the legacy Jekyll builder (which fails: there is no
+      # /docs directory - the site lives in docs-site/ and is built by MkDocs).
+      - name: Pin the Pages build type to GitHub Actions
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh api -X PUT "repos/${{ github.repository }}/pages" -f build_type=workflow \
+            || gh api -X POST "repos/${{ github.repository }}/pages" -f build_type=workflow \
+            || echo "::warning::Could not set the Pages build type; switch Settings -> Pages -> Source to 'GitHub Actions' by hand."
+
       - id: deployment
         uses: actions/deploy-pages@v4


### PR DESCRIPTION
## What broke

Since the Dependabot merges, the **`pages build and deployment`** check on `master` fails:

```
Conversion error: Jekyll::Converters::Scss ... 'assets/css/style.scss':
No such file or directory @ dir_chdir0 - /github/workspace/docs
```

GitHub is running its **legacy Jekyll builder** against `master:/docs`. That directory doesn't exist — the docs live in `docs-site/` and are built with **MkDocs** by the `Docs` workflow (`actions/deploy-pages`). The failed Jekyll run also left the Pages deployment wedged in `building`.

## Why

The repo still has a **"Deploy from a branch"** publishing source configured (`master` / `/docs`) alongside the intended **"GitHub Actions"** source. Touching the Pages settings (or a re-run) kicks off the Jekyll path, which can only fail here.

Two contributing factors worth knowing:
- Dependabot's auto-merge commits are pushed with `GITHUB_TOKEN`, so they don't trigger the `Docs` (`on: push`) workflow — the site isn't rebuilt/redeployed on a Dependabot merge until the next human push.
- `actions/upload-pages-artifact` was bumped to `v5` (#192) while `deploy-pages` stays on `v4`; that pair is still compatible, but keeping them aligned (Dependabot #194) is advisable.

## What this PR does

Adds a best-effort step to the `deploy` job that re-asserts `build_type=workflow` via the Pages API before `actions/deploy-pages` runs. A leftover branch source can then no longer trigger the Jekyll builder. The step is `continue-on-error` and only prints a `::warning::` if the token can't update the setting.

Merging this (as a normal push, not a bot merge) also triggers a fresh `Docs` run that deploys the MkDocs site and clears the stuck deployment.

## Still recommended (cannot be done from a PR)

- **Settings → Pages → Build and deployment → Source → "GitHub Actions"**, and clear the `master /docs` branch source so it can't be re-selected by accident.

🤖 Generated with [Claude Code](https://claude.com/claude-code)