### PR TITLE
docs: fix online docs link 404 in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 Infection/survival style gameplay for sourcemod
 
 ### Docs
-Find all cvars details on [online docs](https://srcdslab.github.io/sm-plugin-zombiereloaded/docs/)
+Find all cvars details on [online docs](https://srcdslab.github.io/sm-plugin-zombiereloaded/)
 
 ## Commands
 


### PR DESCRIPTION
## Problem

The `### Docs` link in the root `README.md` points to:

```
https://srcdslab.github.io/sm-plugin-zombiereloaded/docs/
```

That path does not exist. The MkDocs site is published to the **root** of the GitHub Pages site (`actions/deploy-pages` uploads the built `site/` directory directly, and `mkdocs.yml` sets `site_url: https://srcdslab.github.io/sm-plugin-zombiereloaded/`). The `/docs/` suffix lands on the theme's "404 - Not found" page even though the site itself is live.

## Fix

Drop the stale `/docs/` suffix so the link points at the docs home page. This was the only reference to the broken URL in the repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)