### PR TITLE
fix(classes): capture the original player model before any class model is applied

### DIFF
--- a/docs-site/docs/guide/configuration.md
+++ b/docs-site/docs/guide/configuration.md
@@ -96,35 +96,6 @@
 
 <blockquote><table> <caption>Log Console commands</caption> <tr> <th>Syntax:</th> </tr> <tr> <td class="commandheader">zr_log_add_module &lt;module&gt; [modules...]</td> </tr> <tr> <td class="indent"> <p>Adds one or more modules to the module filter. Use short module names, see <a href="#list-of-modules">List Of Modules (3.3.2)</a>.</p> <p>Parameters:</p> <blockquote><table> <tr><td class="parameter">module</td><td>Name of the module to add.</td></tr> <tr><td class="parameter">modules</td><td>Additional modules to add.</td></tr> </table></blockquote> </td> </tr> <tr> <td class="commandheader">zr_log_remove_module &lt;module&gt; [modules...]</td> </tr> <tr> <td class="indent"> <p>Removes one or more modules from the module filter. Use short module names, see <a href="#list-of-modules">List Of Modules (3.3.2)</a>.</p> <p>Parameters:</p> <blockquote><table> <tr><td class="parameter">module</td><td>Name of the module to remove.</td></tr> <tr><td class="parameter">modules</td><td>Additional modules to remove.</td></tr> </table></blockquote> </td> </tr> <tr> <td class="commandheader">zr_log_list</td> </tr> <tr> <td class="indent"> <p>Lists current log flag settings and module filtering settings.</p> </td> </tr> </table></blockquote>
 
-### Model Tracing
-
-<p>Every model decision the plugin makes can be traced, to diagnose players ending up with the wrong skin. Traces are written under <code>LOG_DEBUG_DETAIL</code> with the fixed description <code>Model Trace</code>, so the whole session can be pulled out of the SourceMod log with a single grep.</p>
-
-To enable it, in the main configuration file:
-
-```
-zr_log                  1
-zr_log_flags            18      // 2 (LOG_GAME_EVENTS) + 16 (LOG_DEBUG_DETAIL)
-zr_log_module_filter    1
-zr_log_add_module       playerclasses
-```
-
-Then collect the trace with:
-
-```
-grep "Model Trace" addons/sourcemod/logs/L*.log
-```
-
-Three kinds of line are written, each carrying the player's name, userid, SteamID, team and zombie state so a single player can be followed across rounds:
-
-| Line | When | Key fields |
-| --- | --- | --- |
-| `init` | Client enters a player slot | `dropped` - the cached original model being discarded with the previous occupant |
-| `capture` | Start of every spawn, before any class model is applied | `read` - model found on the player; `result` - `stored` or `skipped`; `reason` - `empty`, `models.txt` or `plugin-applied`; `kept`/`previous` - the cached original |
-| `apply` | Every call that applies a class model | `class`, `cfg` - the class `model_path` as configured; `resolved` - the path actually used; `result` - `applied`, `skipped`, `blocked` or `preset-fallback`; `original` - the cached original model |
-
-<p>A player wearing the wrong skin should show a <code>capture</code> line whose <code>read</code> is a zombie model, or an <code>apply</code> line with <code>cfg="default"</code> whose <code>original</code> is a zombie model. Leave the flag off on a normal server: it writes several lines per player per round.</p>
-
 ### Log Flags
 
 <blockquote><table> <caption>Log Flags</caption> <tr> <th class="namewidth">Flag:</th> <th class="tinywidth">Bit No.:</th> <th class="tinywidth">Value:</th> <th>Description:</th> </tr> <tr> <td class="code">LOG_CORE_EVENTS</td> <td>1</td> <td>1</td> <td>Log events from the plugin core like config validation and other messages.</td> </tr> <tr> <td class="code">LOG_GAME_EVENTS</td> <td>2</td> <td>2</td> <td>Log admin commands, console commands, and game related events from modules like, suicide attempts and weapon restrictions.</td> </tr> <tr> <td class="code">LOG_PLAYER_COMMANDS</td> <td>3</td> <td>4</td> <td>Log events that are triggered by players, like chat triggers, teleporting and class changes.</td> </tr> <tr> <td class="code">LOG_DEBUG</td> <td>4</td> <td>8</td> <td>Log debug messages, if any. Usually only developers need to enable this log flag.</td> </tr> <tr> <td class="code">LOG_DEBUG_DETAIL</td> <td>5</td> <td>16</td> <td>Log additional debug messages with more details. May cause spam depending on module filter settings. Usually only developers need to enable this log flag.</td> </tr> </table></blockquote>

--- a/docs-site/docs/guide/configuration.md
+++ b/docs-site/docs/guide/configuration.md
@@ -96,6 +96,35 @@
 
 <blockquote><table> <caption>Log Console commands</caption> <tr> <th>Syntax:</th> </tr> <tr> <td class="commandheader">zr_log_add_module &lt;module&gt; [modules...]</td> </tr> <tr> <td class="indent"> <p>Adds one or more modules to the module filter. Use short module names, see <a href="#list-of-modules">List Of Modules (3.3.2)</a>.</p> <p>Parameters:</p> <blockquote><table> <tr><td class="parameter">module</td><td>Name of the module to add.</td></tr> <tr><td class="parameter">modules</td><td>Additional modules to add.</td></tr> </table></blockquote> </td> </tr> <tr> <td class="commandheader">zr_log_remove_module &lt;module&gt; [modules...]</td> </tr> <tr> <td class="indent"> <p>Removes one or more modules from the module filter. Use short module names, see <a href="#list-of-modules">List Of Modules (3.3.2)</a>.</p> <p>Parameters:</p> <blockquote><table> <tr><td class="parameter">module</td><td>Name of the module to remove.</td></tr> <tr><td class="parameter">modules</td><td>Additional modules to remove.</td></tr> </table></blockquote> </td> </tr> <tr> <td class="commandheader">zr_log_list</td> </tr> <tr> <td class="indent"> <p>Lists current log flag settings and module filtering settings.</p> </td> </tr> </table></blockquote>
 
+### Model Tracing
+
+<p>Every model decision the plugin makes can be traced, to diagnose players ending up with the wrong skin. Traces are written under <code>LOG_DEBUG_DETAIL</code> with the fixed description <code>Model Trace</code>, so the whole session can be pulled out of the SourceMod log with a single grep.</p>
+
+To enable it, in the main configuration file:
+
+```
+zr_log                  1
+zr_log_flags            18      // 2 (LOG_GAME_EVENTS) + 16 (LOG_DEBUG_DETAIL)
+zr_log_module_filter    1
+zr_log_add_module       playerclasses
+```
+
+Then collect the trace with:
+
+```
+grep "Model Trace" addons/sourcemod/logs/L*.log
+```
+
+Three kinds of line are written, each carrying the player's name, userid, SteamID, team and zombie state so a single player can be followed across rounds:
+
+| Line | When | Key fields |
+| --- | --- | --- |
+| `init` | Client enters a player slot | `dropped` - the cached original model being discarded with the previous occupant |
+| `capture` | Start of every spawn, before any class model is applied | `read` - model found on the player; `result` - `stored` or `skipped`; `reason` - `empty`, `models.txt` or `plugin-applied`; `kept`/`previous` - the cached original |
+| `apply` | Every call that applies a class model | `class`, `cfg` - the class `model_path` as configured; `resolved` - the path actually used; `result` - `applied`, `skipped`, `blocked` or `preset-fallback`; `original` - the cached original model |
+
+<p>A player wearing the wrong skin should show a <code>capture</code> line whose <code>read</code> is a zombie model, or an <code>apply</code> line with <code>cfg="default"</code> whose <code>original</code> is a zombie model. Leave the flag off on a normal server: it writes several lines per player per round.</p>
+
 ### Log Flags
 
 <blockquote><table> <caption>Log Flags</caption> <tr> <th class="namewidth">Flag:</th> <th class="tinywidth">Bit No.:</th> <th class="tinywidth">Value:</th> <th>Description:</th> </tr> <tr> <td class="code">LOG_CORE_EVENTS</td> <td>1</td> <td>1</td> <td>Log events from the plugin core like config validation and other messages.</td> </tr> <tr> <td class="code">LOG_GAME_EVENTS</td> <td>2</td> <td>2</td> <td>Log admin commands, console commands, and game related events from modules like, suicide attempts and weapon restrictions.</td> </tr> <tr> <td class="code">LOG_PLAYER_COMMANDS</td> <td>3</td> <td>4</td> <td>Log events that are triggered by players, like chat triggers, teleporting and class changes.</td> </tr> <tr> <td class="code">LOG_DEBUG</td> <td>4</td> <td>8</td> <td>Log debug messages, if any. Usually only developers need to enable this log flag.</td> </tr> <tr> <td class="code">LOG_DEBUG_DETAIL</td> <td>5</td> <td>16</td> <td>Log additional debug messages with more details. May cause spam depending on module filter settings. Usually only developers need to enable this log flag.</td> </tr> </table></blockquote>

--- a/src/addons/sourcemod/scripting/zr/event.inc
+++ b/src/addons/sourcemod/scripting/zr/event.inc
@@ -201,6 +201,7 @@ public Action EventPlayerSpawn(Event event, const char[] name, bool dontBroadcas
         return Plugin_Continue;
 
     // Forward event to modules.
+    ClassOnClientSpawnPre(index);   // Must run first: records the player's own model before any class model is applied.
     InfectOnClientSpawn(index);     // Some modules depend on this to finish first.
     AccountOnClientSpawn(index);    // Some modules depend on this to finish first.
     ClassOnClientSpawn(index);

--- a/src/addons/sourcemod/scripting/zr/hgversion.h.inc
+++ b/src/addons/sourcemod/scripting/zr/hgversion.h.inc
@@ -4,7 +4,7 @@
 #define ZR_VER_BRANCH           "master"
 #define ZR_VER_MAJOR            "3"
 #define ZR_VER_MINOR            "13"
-#define ZR_VER_PATCH            "15"
+#define ZR_VER_PATCH            "16"
 #define ZR_VERSION              ZR_VER_MAJOR..."."...ZR_VER_MINOR..."."...ZR_VER_PATCH
 #define ZR_VER_LICENSE          "GNU GPL, Version 3"
 #define ZR_VER_DATE             "Fri Sep 04 CEST 2026"

--- a/src/addons/sourcemod/scripting/zr/models.inc
+++ b/src/addons/sourcemod/scripting/zr/models.inc
@@ -619,6 +619,31 @@ bool ModelsIsManagedPath(const char[] path)
 }
 
 /**
+ * Converts a team setting to a readable string, for logs.
+ *
+ * @param team      Team setting to convert.
+ * @param buffer    Destination string buffer.
+ * @param maxlen    Size of buffer.
+ * @return          Number of cells written.
+ */
+int ModelsTeamToString(ModelTeam team, char[] buffer, int maxlen)
+{
+    switch (team)
+    {
+        case ModelTeam_Zombies:
+        {
+            return strcopy(buffer, maxlen, "zombies");
+        }
+        case ModelTeam_Humans:
+        {
+            return strcopy(buffer, maxlen, "humans");
+        }
+    }
+
+    return strcopy(buffer, maxlen, "invalid");
+}
+
+/**
  * Converts the specified string to a team setting.
  *
  * @param team  String to convert.

--- a/src/addons/sourcemod/scripting/zr/models.inc
+++ b/src/addons/sourcemod/scripting/zr/models.inc
@@ -619,31 +619,6 @@ bool ModelsIsManagedPath(const char[] path)
 }
 
 /**
- * Converts a team setting to a readable string, for logs.
- *
- * @param team      Team setting to convert.
- * @param buffer    Destination string buffer.
- * @param maxlen    Size of buffer.
- * @return          Number of cells written.
- */
-int ModelsTeamToString(ModelTeam team, char[] buffer, int maxlen)
-{
-    switch (team)
-    {
-        case ModelTeam_Zombies:
-        {
-            return strcopy(buffer, maxlen, "zombies");
-        }
-        case ModelTeam_Humans:
-        {
-            return strcopy(buffer, maxlen, "humans");
-        }
-    }
-
-    return strcopy(buffer, maxlen, "invalid");
-}
-
-/**
  * Converts the specified string to a team setting.
  *
  * @param team  String to convert.

--- a/src/addons/sourcemod/scripting/zr/models.inc
+++ b/src/addons/sourcemod/scripting/zr/models.inc
@@ -585,6 +585,40 @@ void ModelsGetFullPath(int index, char[] buffer, int maxlen)
 }
 
 /**
+ * Checks if a model path is one of the models managed by this plugin (the ones
+ * listed in models.txt).
+ *
+ * Used to tell a player's own game model apart from a model this plugin has
+ * applied, so a class model is never mistaken for the player's original model.
+ *
+ * @param path      Model path to look up, in the same form as GetClientModel()
+ *                  and ModelsGetFullPath() produce.
+ * @return          True if the path belongs to a configured model, false
+ *                  otherwise. An empty path is never a managed model.
+ */
+bool ModelsIsManagedPath(const char[] path)
+{
+    char fullpath[PLATFORM_MAX_PATH];
+
+    if (!path[0])
+    {
+        return false;
+    }
+
+    for (int index = 0; index < ModelCount; index++)
+    {
+        ModelsGetFullPath(index, fullpath, sizeof(fullpath));
+
+        if (strcmp(path, fullpath, false) == 0)
+        {
+            return true;
+        }
+    }
+
+    return false;
+}
+
+/**
  * Converts the specified string to a team setting.
  *
  * @param team  String to convert.

--- a/src/addons/sourcemod/scripting/zr/playerclasses/apply.inc
+++ b/src/addons/sourcemod/scripting/zr/playerclasses/apply.inc
@@ -87,6 +87,10 @@ bool ClassApplyModel(int client, int classindex, int cachetype = ZR_CLASS_CACHE_
 {
     bool isAttributePreset = false;
     char modelpath[PLATFORM_MAX_PATH];
+    char configpath[PLATFORM_MAX_PATH];
+    char classname[64];
+    char teamname[16];
+    char trace[CLASS_MODEL_TRACE_LENGTH];
     int index;
     ModelTeam team;
     int access;
@@ -111,6 +115,13 @@ bool ClassApplyModel(int client, int classindex, int cachetype = ZR_CLASS_CACHE_
 
     // Get model team setting from the specified cache.
     team = ModelsTeamIdToTeam(ClassGetTeamID(index, cachetype));
+
+    // Build the trace context. configpath keeps the value straight from the
+    // class config, which modelpath is about to be resolved away from.
+    strcopy(configpath, sizeof(configpath), modelpath);
+    ClassGetName(index, classname, sizeof(classname), cachetype);
+    ModelsTeamToString(team, teamname, sizeof(teamname));
+    ClassModelTraceClient(client, trace, sizeof(trace));
 
     // Check if the user specified a pre-defined model setting. If so, setup
     // model filter settings.
@@ -155,6 +166,7 @@ bool ClassApplyModel(int client, int classindex, int cachetype = ZR_CLASS_CACHE_
         // restoring an empty path.
         if (!ClassOriginalPlayerModel[client][0])
         {
+            LogEvent(false, LogType_Normal, LOG_DEBUG_DETAIL, LogModule_Playerclasses, "Model Trace", "apply %s class=\"%s\" cfg=\"%s\" result=skipped reason=no-original", trace, classname, configpath);
             return true;
         }
 
@@ -169,12 +181,14 @@ bool ClassApplyModel(int client, int classindex, int cachetype = ZR_CLASS_CACHE_
         else
         {
             // Wanted model is already set, don't change.
+            LogEvent(false, LogType_Normal, LOG_DEBUG_DETAIL, LogModule_Playerclasses, "Model Trace", "apply %s class=\"%s\" cfg=\"%s\" resolved=\"%s\" result=skipped reason=already-set", trace, classname, configpath, modelpath);
             return true;
         }
     }
     else if (strcmp(modelpath, "no_change", false) == 0)
     {
         // Do nothing.
+        LogEvent(false, LogType_Normal, LOG_DEBUG_DETAIL, LogModule_Playerclasses, "Model Trace", "apply %s class=\"%s\" cfg=\"%s\" result=skipped reason=no_change", trace, classname, configpath);
         return true;
     }
 
@@ -196,6 +210,8 @@ bool ClassApplyModel(int client, int classindex, int cachetype = ZR_CLASS_CACHE_
             // public model. Then get its path.
             model = ModelsGetRandomModel(-1, team, MODEL_ACCESS_PUBLIC);
             ModelsGetFullPath(model, modelpath, sizeof(modelpath));
+
+            LogEvent(false, LogType_Normal, LOG_DEBUG_DETAIL, LogModule_Playerclasses, "Model Trace", "apply %s class=\"%s\" cfg=\"%s\" result=preset-fallback team=%s access=%d model=%d resolved=\"%s\"", trace, classname, configpath, teamname, access, model, modelpath);
         }
     }
 
@@ -205,6 +221,7 @@ bool ClassApplyModel(int client, int classindex, int cachetype = ZR_CLASS_CACHE_
     // Check if application should be stopped.
     if (result == Plugin_Handled)
     {
+        LogEvent(false, LogType_Normal, LOG_DEBUG_DETAIL, LogModule_Playerclasses, "Model Trace", "apply %s class=\"%s\" cfg=\"%s\" resolved=\"%s\" result=blocked reason=api-forward", trace, classname, configpath, modelpath);
         return false;
     }
 
@@ -212,6 +229,7 @@ bool ClassApplyModel(int client, int classindex, int cachetype = ZR_CLASS_CACHE_
     if (!IsModelPrecached(modelpath))
     {
         LogEvent(false, LogType_Error, LOG_CORE_EVENTS, LogModule_Playerclasses, "Config Validation", "Warning: Model not precached, not applying model. \"%s\"", modelpath);
+        LogEvent(false, LogType_Normal, LOG_DEBUG_DETAIL, LogModule_Playerclasses, "Model Trace", "apply %s class=\"%s\" cfg=\"%s\" resolved=\"%s\" result=skipped reason=not-precached", trace, classname, configpath, modelpath);
         return true;
     }
 
@@ -220,6 +238,8 @@ bool ClassApplyModel(int client, int classindex, int cachetype = ZR_CLASS_CACHE_
 
     // Remember what we applied, so it can't come back as an "original" model.
     strcopy(ClassAppliedPlayerModel[client], PLATFORM_MAX_PATH, modelpath);
+
+    LogEvent(false, LogType_Normal, LOG_DEBUG_DETAIL, LogModule_Playerclasses, "Model Trace", "apply %s class=\"%s\" cfg=\"%s\" resolved=\"%s\" skin=%d team=%s result=applied original=\"%s\"", trace, classname, configpath, modelpath, skinIndex, teamname, ClassOriginalPlayerModel[client]);
 
     // Trigger API forward.
     APIOnClassModelApplied(client, modelpath, skinIndex);

--- a/src/addons/sourcemod/scripting/zr/playerclasses/apply.inc
+++ b/src/addons/sourcemod/scripting/zr/playerclasses/apply.inc
@@ -87,10 +87,6 @@ bool ClassApplyModel(int client, int classindex, int cachetype = ZR_CLASS_CACHE_
 {
     bool isAttributePreset = false;
     char modelpath[PLATFORM_MAX_PATH];
-    char configpath[PLATFORM_MAX_PATH];
-    char classname[64];
-    char teamname[16];
-    char trace[CLASS_MODEL_TRACE_LENGTH];
     int index;
     ModelTeam team;
     int access;
@@ -115,13 +111,6 @@ bool ClassApplyModel(int client, int classindex, int cachetype = ZR_CLASS_CACHE_
 
     // Get model team setting from the specified cache.
     team = ModelsTeamIdToTeam(ClassGetTeamID(index, cachetype));
-
-    // Build the trace context. configpath keeps the value straight from the
-    // class config, which modelpath is about to be resolved away from.
-    strcopy(configpath, sizeof(configpath), modelpath);
-    ClassGetName(index, classname, sizeof(classname), cachetype);
-    ModelsTeamToString(team, teamname, sizeof(teamname));
-    ClassModelTraceClient(client, trace, sizeof(trace));
 
     // Check if the user specified a pre-defined model setting. If so, setup
     // model filter settings.
@@ -166,7 +155,6 @@ bool ClassApplyModel(int client, int classindex, int cachetype = ZR_CLASS_CACHE_
         // restoring an empty path.
         if (!ClassOriginalPlayerModel[client][0])
         {
-            LogEvent(false, LogType_Normal, LOG_DEBUG_DETAIL, LogModule_Playerclasses, "Model Trace", "apply %s class=\"%s\" cfg=\"%s\" result=skipped reason=no-original", trace, classname, configpath);
             return true;
         }
 
@@ -181,14 +169,12 @@ bool ClassApplyModel(int client, int classindex, int cachetype = ZR_CLASS_CACHE_
         else
         {
             // Wanted model is already set, don't change.
-            LogEvent(false, LogType_Normal, LOG_DEBUG_DETAIL, LogModule_Playerclasses, "Model Trace", "apply %s class=\"%s\" cfg=\"%s\" resolved=\"%s\" result=skipped reason=already-set", trace, classname, configpath, modelpath);
             return true;
         }
     }
     else if (strcmp(modelpath, "no_change", false) == 0)
     {
         // Do nothing.
-        LogEvent(false, LogType_Normal, LOG_DEBUG_DETAIL, LogModule_Playerclasses, "Model Trace", "apply %s class=\"%s\" cfg=\"%s\" result=skipped reason=no_change", trace, classname, configpath);
         return true;
     }
 
@@ -210,8 +196,6 @@ bool ClassApplyModel(int client, int classindex, int cachetype = ZR_CLASS_CACHE_
             // public model. Then get its path.
             model = ModelsGetRandomModel(-1, team, MODEL_ACCESS_PUBLIC);
             ModelsGetFullPath(model, modelpath, sizeof(modelpath));
-
-            LogEvent(false, LogType_Normal, LOG_DEBUG_DETAIL, LogModule_Playerclasses, "Model Trace", "apply %s class=\"%s\" cfg=\"%s\" result=preset-fallback team=%s access=%d model=%d resolved=\"%s\"", trace, classname, configpath, teamname, access, model, modelpath);
         }
     }
 
@@ -221,7 +205,6 @@ bool ClassApplyModel(int client, int classindex, int cachetype = ZR_CLASS_CACHE_
     // Check if application should be stopped.
     if (result == Plugin_Handled)
     {
-        LogEvent(false, LogType_Normal, LOG_DEBUG_DETAIL, LogModule_Playerclasses, "Model Trace", "apply %s class=\"%s\" cfg=\"%s\" resolved=\"%s\" result=blocked reason=api-forward", trace, classname, configpath, modelpath);
         return false;
     }
 
@@ -229,7 +212,6 @@ bool ClassApplyModel(int client, int classindex, int cachetype = ZR_CLASS_CACHE_
     if (!IsModelPrecached(modelpath))
     {
         LogEvent(false, LogType_Error, LOG_CORE_EVENTS, LogModule_Playerclasses, "Config Validation", "Warning: Model not precached, not applying model. \"%s\"", modelpath);
-        LogEvent(false, LogType_Normal, LOG_DEBUG_DETAIL, LogModule_Playerclasses, "Model Trace", "apply %s class=\"%s\" cfg=\"%s\" resolved=\"%s\" result=skipped reason=not-precached", trace, classname, configpath, modelpath);
         return true;
     }
 
@@ -238,8 +220,6 @@ bool ClassApplyModel(int client, int classindex, int cachetype = ZR_CLASS_CACHE_
 
     // Remember what we applied, so it can't come back as an "original" model.
     strcopy(ClassAppliedPlayerModel[client], PLATFORM_MAX_PATH, modelpath);
-
-    LogEvent(false, LogType_Normal, LOG_DEBUG_DETAIL, LogModule_Playerclasses, "Model Trace", "apply %s class=\"%s\" cfg=\"%s\" resolved=\"%s\" skin=%d team=%s result=applied original=\"%s\"", trace, classname, configpath, modelpath, skinIndex, teamname, ClassOriginalPlayerModel[client]);
 
     // Trigger API forward.
     APIOnClassModelApplied(client, modelpath, skinIndex);

--- a/src/addons/sourcemod/scripting/zr/playerclasses/apply.inc
+++ b/src/addons/sourcemod/scripting/zr/playerclasses/apply.inc
@@ -150,14 +150,6 @@ bool ClassApplyModel(int client, int classindex, int cachetype = ZR_CLASS_CACHE_
     }
     else if (strcmp(modelpath, "default", false) == 0)
     {
-        // No original model captured yet (client hasn't had its first spawn).
-        // Leave the current model alone rather than restoring an empty or stale
-        // path.
-        if (!ClassOriginalPlayerModel[client][0])
-        {
-            return true;
-        }
-
         // Get current model.
         GetClientModel(client, modelpath, sizeof(modelpath));
 

--- a/src/addons/sourcemod/scripting/zr/playerclasses/apply.inc
+++ b/src/addons/sourcemod/scripting/zr/playerclasses/apply.inc
@@ -150,6 +150,14 @@ bool ClassApplyModel(int client, int classindex, int cachetype = ZR_CLASS_CACHE_
     }
     else if (strcmp(modelpath, "default", false) == 0)
     {
+        // Nothing captured yet, or nothing usable was seen (see
+        // ClassOnClientSpawnPre). Leave the current model alone rather than
+        // restoring an empty path.
+        if (!ClassOriginalPlayerModel[client][0])
+        {
+            return true;
+        }
+
         // Get current model.
         GetClientModel(client, modelpath, sizeof(modelpath));
 
@@ -209,6 +217,9 @@ bool ClassApplyModel(int client, int classindex, int cachetype = ZR_CLASS_CACHE_
 
     SetEntityModel(client, modelpath);
     SetEntProp(client, Prop_Send, "m_nSkin", skinIndex);
+
+    // Remember what we applied, so it can't come back as an "original" model.
+    strcopy(ClassAppliedPlayerModel[client], PLATFORM_MAX_PATH, modelpath);
 
     // Trigger API forward.
     APIOnClassModelApplied(client, modelpath, skinIndex);

--- a/src/addons/sourcemod/scripting/zr/playerclasses/classevents.inc
+++ b/src/addons/sourcemod/scripting/zr/playerclasses/classevents.inc
@@ -131,6 +131,10 @@ void ClassClientInit(int client)
     // Reset spawn flag.
     ClassPlayerSpawned[client] = false;
 
+    char trace[CLASS_MODEL_TRACE_LENGTH];
+    ClassModelTraceClient(client, trace, sizeof(trace));
+    LogEvent(false, LogType_Normal, LOG_DEBUG_DETAIL, LogModule_Playerclasses, "Model Trace", "init %s dropped=\"%s\"", trace, ClassOriginalPlayerModel[client]);
+
     // Drop the previous occupant's original model. The new player's own model
     // is captured on their first spawn; until then there is nothing to restore.
     ClassOriginalPlayerModel[client][0] = 0;
@@ -220,6 +224,7 @@ void ClassOnClientDisconnect(int client)
 void ClassOnClientSpawnPre(int client)
 {
     char originalmodel[PLATFORM_MAX_PATH];
+    char trace[CLASS_MODEL_TRACE_LENGTH];
 
     // Check if the player is dead. Spawning into the game is also a event in
     // the connection process.
@@ -230,17 +235,34 @@ void ClassOnClientSpawnPre(int client)
 
     GetClientModel(client, originalmodel, sizeof(originalmodel));
 
+    ClassModelTraceClient(client, trace, sizeof(trace));
+
     // Never record a model this plugin applied. Even this early the player can
     // still be wearing a class model: the game does not always reset the model
     // before player_spawn fires, and InfectOnClientSpawn() respawns team-swapped
     // players through CS_RespawnPlayer(), which fires a nested player_spawn.
     // Keeping the last known good value beats caching a zombie skin.
-    if (!originalmodel[0] ||
-        ModelsIsManagedPath(originalmodel) ||
-        strcmp(originalmodel, ClassAppliedPlayerModel[client], false) == 0)
+    //
+    // The three rejections are kept apart so the trace says which one fired.
+    if (!originalmodel[0])
     {
+        LogEvent(false, LogType_Normal, LOG_DEBUG_DETAIL, LogModule_Playerclasses, "Model Trace", "capture %s read=\"\" result=skipped reason=empty kept=\"%s\"", trace, ClassOriginalPlayerModel[client]);
         return;
     }
+
+    if (ModelsIsManagedPath(originalmodel))
+    {
+        LogEvent(false, LogType_Normal, LOG_DEBUG_DETAIL, LogModule_Playerclasses, "Model Trace", "capture %s read=\"%s\" result=skipped reason=models.txt kept=\"%s\"", trace, originalmodel, ClassOriginalPlayerModel[client]);
+        return;
+    }
+
+    if (strcmp(originalmodel, ClassAppliedPlayerModel[client], false) == 0)
+    {
+        LogEvent(false, LogType_Normal, LOG_DEBUG_DETAIL, LogModule_Playerclasses, "Model Trace", "capture %s read=\"%s\" result=skipped reason=plugin-applied kept=\"%s\"", trace, originalmodel, ClassOriginalPlayerModel[client]);
+        return;
+    }
+
+    LogEvent(false, LogType_Normal, LOG_DEBUG_DETAIL, LogModule_Playerclasses, "Model Trace", "capture %s read=\"%s\" result=stored previous=\"%s\"", trace, originalmodel, ClassOriginalPlayerModel[client]);
 
     strcopy(ClassOriginalPlayerModel[client], PLATFORM_MAX_PATH, originalmodel);
 }

--- a/src/addons/sourcemod/scripting/zr/playerclasses/classevents.inc
+++ b/src/addons/sourcemod/scripting/zr/playerclasses/classevents.inc
@@ -130,6 +130,11 @@ void ClassClientInit(int client)
 
     // Reset spawn flag.
     ClassPlayerSpawned[client] = false;
+
+    // Drop the previous occupant's original model. The new player's own model
+    // is captured on their first spawn; until then there is nothing to restore.
+    ClassOriginalPlayerModel[client][0] = 0;
+    ClassAppliedPlayerModel[client][0] = 0;
 }
 
 /**
@@ -198,13 +203,55 @@ void ClassOnClientDisconnect(int client)
 }
 
 /**
+ * Client is spawning into the game, before any other module has handled the
+ * spawn.
+ *
+ * Captures the player's original model - the model they would have without this
+ * plugin - for classes whose model is "default".
+ *
+ * This has to run before the other spawn handlers: InfectOnClientSpawn() infects
+ * players who spawn once the mother zombie is out, which applies a class model
+ * straight away. Reading the model after that would record this plugin's zombie
+ * model as the player's own, and a later "default" restore (zr_human, or the
+ * next human life) would hand that zombie skin back - issue #55.
+ *
+ * @param client    The client index.
+ */
+void ClassOnClientSpawnPre(int client)
+{
+    char originalmodel[PLATFORM_MAX_PATH];
+
+    // Check if the player is dead. Spawning into the game is also a event in
+    // the connection process.
+    if (!IsPlayerAlive(client))
+    {
+        return;
+    }
+
+    GetClientModel(client, originalmodel, sizeof(originalmodel));
+
+    // Never record a model this plugin applied. Even this early the player can
+    // still be wearing a class model: the game does not always reset the model
+    // before player_spawn fires, and InfectOnClientSpawn() respawns team-swapped
+    // players through CS_RespawnPlayer(), which fires a nested player_spawn.
+    // Keeping the last known good value beats caching a zombie skin.
+    if (!originalmodel[0] ||
+        ModelsIsManagedPath(originalmodel) ||
+        strcmp(originalmodel, ClassAppliedPlayerModel[client], false) == 0)
+    {
+        return;
+    }
+
+    strcopy(ClassOriginalPlayerModel[client], PLATFORM_MAX_PATH, originalmodel);
+}
+
+/**
  * Client is spawning into the game.
  *
  * @param client    The client index.
  */
 void ClassOnClientSpawn(int client)
 {
-    char originalmodel[PLATFORM_MAX_PATH];
     char classname[64];
     ClassFilter filter;
 
@@ -228,9 +275,8 @@ void ClassOnClientSpawn(int client)
     // Restore class indexes to be selected on spawn, if available.
     ClassRestoreNextIndexes(client);
 
-    // Cache original player model.
-    GetClientModel(client, originalmodel, sizeof(originalmodel));
-    strcopy(ClassOriginalPlayerModel[client], PLATFORM_MAX_PATH, originalmodel);
+    // Note: The original player model is captured in ClassOnClientSpawnPre,
+    //       before any module can apply a class model.
 
     // Check if the player should spawn in admin mode.
     if (ClassPlayerInAdminMode[client])

--- a/src/addons/sourcemod/scripting/zr/playerclasses/classevents.inc
+++ b/src/addons/sourcemod/scripting/zr/playerclasses/classevents.inc
@@ -131,10 +131,6 @@ void ClassClientInit(int client)
     // Reset spawn flag.
     ClassPlayerSpawned[client] = false;
 
-    char trace[CLASS_MODEL_TRACE_LENGTH];
-    ClassModelTraceClient(client, trace, sizeof(trace));
-    LogEvent(false, LogType_Normal, LOG_DEBUG_DETAIL, LogModule_Playerclasses, "Model Trace", "init %s dropped=\"%s\"", trace, ClassOriginalPlayerModel[client]);
-
     // Drop the previous occupant's original model. The new player's own model
     // is captured on their first spawn; until then there is nothing to restore.
     ClassOriginalPlayerModel[client][0] = 0;
@@ -224,7 +220,6 @@ void ClassOnClientDisconnect(int client)
 void ClassOnClientSpawnPre(int client)
 {
     char originalmodel[PLATFORM_MAX_PATH];
-    char trace[CLASS_MODEL_TRACE_LENGTH];
 
     // Check if the player is dead. Spawning into the game is also an event in
     // the connection process.
@@ -235,34 +230,17 @@ void ClassOnClientSpawnPre(int client)
 
     GetClientModel(client, originalmodel, sizeof(originalmodel));
 
-    ClassModelTraceClient(client, trace, sizeof(trace));
-
     // Never record a model this plugin applied. Even this early the player can
     // still be wearing a class model: the game does not always reset the model
     // before player_spawn fires, and InfectOnClientSpawn() respawns team-swapped
     // players through CS_RespawnPlayer(), which fires a nested player_spawn.
     // Keeping the last known good value beats caching a zombie skin.
-    //
-    // The three rejections are kept apart so the trace says which one fired.
-    if (!originalmodel[0])
+    if (!originalmodel[0] ||
+        ModelsIsManagedPath(originalmodel) ||
+        strcmp(originalmodel, ClassAppliedPlayerModel[client], false) == 0)
     {
-        LogEvent(false, LogType_Normal, LOG_DEBUG_DETAIL, LogModule_Playerclasses, "Model Trace", "capture %s read=\"\" result=skipped reason=empty kept=\"%s\"", trace, ClassOriginalPlayerModel[client]);
         return;
     }
-
-    if (ModelsIsManagedPath(originalmodel))
-    {
-        LogEvent(false, LogType_Normal, LOG_DEBUG_DETAIL, LogModule_Playerclasses, "Model Trace", "capture %s read=\"%s\" result=skipped reason=models.txt kept=\"%s\"", trace, originalmodel, ClassOriginalPlayerModel[client]);
-        return;
-    }
-
-    if (strcmp(originalmodel, ClassAppliedPlayerModel[client], false) == 0)
-    {
-        LogEvent(false, LogType_Normal, LOG_DEBUG_DETAIL, LogModule_Playerclasses, "Model Trace", "capture %s read=\"%s\" result=skipped reason=plugin-applied kept=\"%s\"", trace, originalmodel, ClassOriginalPlayerModel[client]);
-        return;
-    }
-
-    LogEvent(false, LogType_Normal, LOG_DEBUG_DETAIL, LogModule_Playerclasses, "Model Trace", "capture %s read=\"%s\" result=stored previous=\"%s\"", trace, originalmodel, ClassOriginalPlayerModel[client]);
 
     strcopy(ClassOriginalPlayerModel[client], PLATFORM_MAX_PATH, originalmodel);
 }

--- a/src/addons/sourcemod/scripting/zr/playerclasses/classevents.inc
+++ b/src/addons/sourcemod/scripting/zr/playerclasses/classevents.inc
@@ -226,7 +226,7 @@ void ClassOnClientSpawnPre(int client)
     char originalmodel[PLATFORM_MAX_PATH];
     char trace[CLASS_MODEL_TRACE_LENGTH];
 
-    // Check if the player is dead. Spawning into the game is also a event in
+    // Check if the player is dead. Spawning into the game is also an event in
     // the connection process.
     if (!IsPlayerAlive(client))
     {

--- a/src/addons/sourcemod/scripting/zr/playerclasses/classevents.inc
+++ b/src/addons/sourcemod/scripting/zr/playerclasses/classevents.inc
@@ -130,12 +130,6 @@ void ClassClientInit(int client)
 
     // Reset spawn flag.
     ClassPlayerSpawned[client] = false;
-
-    // The original model is captured on the client's first spawn. Clear the
-    // stored path too, so a slot reused by a new occupant can't hand the
-    // previous player's model to a "default" restore before that capture runs.
-    ClassOriginalPlayerModelCached[client] = false;
-    ClassOriginalPlayerModel[client][0] = 0;
 }
 
 /**
@@ -234,17 +228,9 @@ void ClassOnClientSpawn(int client)
     // Restore class indexes to be selected on spawn, if available.
     ClassRestoreNextIndexes(client);
 
-    // Cache the original player model, once per connection. Re-reading it on
-    // every spawn is unsafe: right after CS_RespawnPlayer() (zr_respawn +
-    // zr_respawn_team_zombie) the player can still be carrying the zombie model
-    // this module applied last life, and caching that would later restore a
-    // zombie skin onto a human through a class whose model is "default".
-    if (!ClassOriginalPlayerModelCached[client])
-    {
-        GetClientModel(client, originalmodel, sizeof(originalmodel));
-        strcopy(ClassOriginalPlayerModel[client], PLATFORM_MAX_PATH, originalmodel);
-        ClassOriginalPlayerModelCached[client] = true;
-    }
+    // Cache original player model.
+    GetClientModel(client, originalmodel, sizeof(originalmodel));
+    strcopy(ClassOriginalPlayerModel[client], PLATFORM_MAX_PATH, originalmodel);
 
     // Check if the player should spawn in admin mode.
     if (ClassPlayerInAdminMode[client])

--- a/src/addons/sourcemod/scripting/zr/playerclasses/playerclasses.inc
+++ b/src/addons/sourcemod/scripting/zr/playerclasses/playerclasses.inc
@@ -504,48 +504,6 @@ char ClassOriginalPlayerModel[MAXPLAYERS + 1][PLATFORM_MAX_PATH];
 char ClassAppliedPlayerModel[MAXPLAYERS + 1][PLATFORM_MAX_PATH];
 
 /**
- * Length of the client description used in model trace log lines.
- */
-#define CLASS_MODEL_TRACE_LENGTH 256
-
-/**
- * Builds the client description shared by every "Model Trace" log line.
- *
- * Traces are written under LOG_DEBUG_DETAIL (zr_log_flags 16) with the fixed
- * description "Model Trace", so a whole session can be pulled out of the
- * SourceMod log with a single grep and followed per player through the SteamID.
- *
- * @param client    The client index.
- * @param buffer    Destination string buffer.
- * @param maxlen    Size of buffer.
- */
-void ClassModelTraceClient(int client, char[] buffer, int maxlen)
-{
-    char name[MAX_NAME_LENGTH];
-    char steamid[32];
-
-    if (!GetClientName(client, name, sizeof(name)))
-    {
-        strcopy(name, sizeof(name), "?");
-    }
-
-    if (!GetClientAuthId(client, AuthId_Steam2, steamid, sizeof(steamid)))
-    {
-        strcopy(steamid, sizeof(steamid), "?");
-    }
-
-    int team = GetClientTeam(client);
-
-    Format(buffer, maxlen, "client=\"%s\" uid=%d steam=%s team=%s zombie=%d alive=%d",
-            name,
-            GetClientUserId(client),
-            steamid,
-            (team == CS_TEAM_T) ? "T" : ((team == CS_TEAM_CT) ? "CT" : "none"),
-            InfectIsClientInfected(client) ? 1 : 0,
-            IsPlayerAlive(client) ? 1 : 0);
-}
-
-/**
  * Specifies whether a player has spawned.
  */
 bool ClassPlayerSpawned[MAXPLAYERS + 1];

--- a/src/addons/sourcemod/scripting/zr/playerclasses/playerclasses.inc
+++ b/src/addons/sourcemod/scripting/zr/playerclasses/playerclasses.inc
@@ -493,12 +493,6 @@ bool ClassAllowInstantChange[MAXPLAYERS + 1];
 char ClassOriginalPlayerModel[MAXPLAYERS + 1][PLATFORM_MAX_PATH];
 
 /**
- * Whether ClassOriginalPlayerModel has been captured for this client. Captured
- * once per connection so a later "default" restore can't pick up a class model.
- */
-bool ClassOriginalPlayerModelCached[MAXPLAYERS + 1];
-
-/**
  * Specifies whether a player has spawned.
  */
 bool ClassPlayerSpawned[MAXPLAYERS + 1];

--- a/src/addons/sourcemod/scripting/zr/playerclasses/playerclasses.inc
+++ b/src/addons/sourcemod/scripting/zr/playerclasses/playerclasses.inc
@@ -489,8 +489,19 @@ bool ClassAllowInstantChange[MAXPLAYERS + 1];
 /**
  * Cache for storing original model path before applying custom models. Used
  * when restoring to old model.
+ *
+ * Only ever holds a model this plugin does not manage - it is refreshed in
+ * ClassOnClientSpawnPre, which skips paths listed in models.txt. Empty means
+ * nothing usable has been seen yet, and "default" leaves the model untouched.
  */
 char ClassOriginalPlayerModel[MAXPLAYERS + 1][PLATFORM_MAX_PATH];
+
+/**
+ * The last model this plugin applied to a player, so ClassOnClientSpawnPre can
+ * recognise it and never mistake it for the player's own model. Covers class
+ * models that aren't listed in models.txt, which ModelsIsManagedPath can't see.
+ */
+char ClassAppliedPlayerModel[MAXPLAYERS + 1][PLATFORM_MAX_PATH];
 
 /**
  * Specifies whether a player has spawned.

--- a/src/addons/sourcemod/scripting/zr/playerclasses/playerclasses.inc
+++ b/src/addons/sourcemod/scripting/zr/playerclasses/playerclasses.inc
@@ -504,6 +504,48 @@ char ClassOriginalPlayerModel[MAXPLAYERS + 1][PLATFORM_MAX_PATH];
 char ClassAppliedPlayerModel[MAXPLAYERS + 1][PLATFORM_MAX_PATH];
 
 /**
+ * Length of the client description used in model trace log lines.
+ */
+#define CLASS_MODEL_TRACE_LENGTH 256
+
+/**
+ * Builds the client description shared by every "Model Trace" log line.
+ *
+ * Traces are written under LOG_DEBUG_DETAIL (zr_log_flags 16) with the fixed
+ * description "Model Trace", so a whole session can be pulled out of the
+ * SourceMod log with a single grep and followed per player through the SteamID.
+ *
+ * @param client    The client index.
+ * @param buffer    Destination string buffer.
+ * @param maxlen    Size of buffer.
+ */
+void ClassModelTraceClient(int client, char[] buffer, int maxlen)
+{
+    char name[MAX_NAME_LENGTH];
+    char steamid[32];
+
+    if (!GetClientName(client, name, sizeof(name)))
+    {
+        strcopy(name, sizeof(name), "?");
+    }
+
+    if (!GetClientAuthId(client, AuthId_Steam2, steamid, sizeof(steamid)))
+    {
+        strcopy(steamid, sizeof(steamid), "?");
+    }
+
+    int team = GetClientTeam(client);
+
+    Format(buffer, maxlen, "client=\"%s\" uid=%d steam=%s team=%s zombie=%d alive=%d",
+            name,
+            GetClientUserId(client),
+            steamid,
+            (team == CS_TEAM_T) ? "T" : ((team == CS_TEAM_CT) ? "CT" : "none"),
+            InfectIsClientInfected(client) ? 1 : 0,
+            IsPlayerAlive(client) ? 1 : 0);
+}
+
+/**
  * Specifies whether a player has spawned.
  */
 bool ClassPlayerSpawned[MAXPLAYERS + 1];


### PR DESCRIPTION
Reverts #189 (`49d966f`) and fixes #55 properly.

## What went wrong

#189 is causing live reports of **humans spawning with zombie skins**:

> zombiereloaded is bugged / some humans spawn with zombie skin
> hey rush humans getting zm skins

It changed `ClassOriginalPlayerModel` from *re-read on every spawn* to *captured once per connection*. But the capture point was already wrong, and freezing it turned an intermittent bug into a permanent one.

`EventPlayerSpawn()` forwards to modules in this order:

```sourcepawn
InfectOnClientSpawn(index);   // -> ZSpawnOnClientSpawn
                              // -> InfectHumanToZombie
                              // -> ClassReloadPlayer
                              // -> ClassApplyModel -> SetEntityModel(<zombie model>)
ClassOnClientSpawn(index);    // -> GetClientModel() reads it back
```

A player who spawns once the mother zombie is out is infected by `InfectOnClientSpawn()` **before** `ClassOnClientSpawn()` reads the model. The zombie model this plugin just applied is therefore recorded as their "original", and every later `model_path "default"` restore hands that zombie skin back.

That is #55 (`zr_human` leaves the player with a zombie model). With #189's capture-once it also became "humans spawn with zombie skins" **for the rest of the connection** — it hits exactly the players who first spawned mid-round, which is why it looked like "*some* humans". Before #189 the value was re-read each spawn so it self-healed next round.

## The fix

Fix the capture *point*, not the frequency.

- **`ClassOnClientSpawnPre()` runs first** in `EventPlayerSpawn()`, before any module can apply a class model, and re-captures on every spawn so a bad value self-heals instead of sticking for the session.
- **It refuses to record a model this plugin applied**, via two independent checks:
  - `ModelsIsManagedPath()` — the path is listed in `models.txt`;
  - `ClassAppliedPlayerModel[client]` — the exact path last handed to `SetEntityModel()` for that client, which also covers class models that aren't in `models.txt`.

  Both are needed because the game does not always reset the player model before `player_spawn` fires, and because `InfectOnClientSpawn()` respawns team-swapped players through `CS_RespawnPlayer()`, firing a nested `player_spawn`.

Kept from #189, since both were real fixes:
- `ClassClientInit()` clears the stored path so a reused slot can't inherit the previous occupant's model;
- `"default"` is a no-op while nothing has been captured, instead of restoring an empty path (this also silenced a bogus `Model not precached ""` warning).

## Not affected

#168 (`c896516`, the per-team precache fail state) stays in place — it never touches model application and is unrelated to this report. #165 stays closed.

## Testing

Compiles clean with spcomp 1.12.0.7210, no warnings.

Worth checking on a live server:
- join mid-round after the mother zombie has spawned, then survive into the next round as a human — should get the normal CT model, not a zombie skin;
- `zr_human <target>` on a zombie — should restore the human model (#55);
- `zr_respawn` with `zr_respawn_team_zombie` enabled;
- a class using `model_path "default"` alongside classes using explicit model paths.

Fixes #55

🤖 Generated with [Claude Code](https://claude.com/claude-code)
