### PR TITLE
fix(log): module filter add/remove never worked

### DIFF
--- a/src/addons/sourcemod/scripting/zr/hgversion.h.inc
+++ b/src/addons/sourcemod/scripting/zr/hgversion.h.inc
@@ -4,7 +4,7 @@
 #define ZR_VER_BRANCH           "master"
 #define ZR_VER_MAJOR            "3"
 #define ZR_VER_MINOR            "13"
-#define ZR_VER_PATCH            "14"
+#define ZR_VER_PATCH            "15"
 #define ZR_VERSION              ZR_VER_MAJOR..."."...ZR_VER_MINOR..."."...ZR_VER_PATCH
 #define ZR_VER_LICENSE          "GNU GPL, Version 3"
 #define ZR_VER_DATE             "Fri Sep 04 CEST 2026"

--- a/src/addons/sourcemod/scripting/zr/log.inc
+++ b/src/addons/sourcemod/scripting/zr/log.inc
@@ -370,14 +370,14 @@ bool LogModuleFilterAdd(LogModules module)
 {
     char modulename[64];
 
+    // Convert module name.
+    LogGetModuleNameString(modulename, sizeof(modulename), module, true);
+
     // Check if empty.
     if (strlen(modulename) == 0)
     {
         return false;
     }
-
-    // Convert module name.
-    LogGetModuleNameString(modulename, sizeof(modulename), module, true);
 
     // Check if the module isn't already is listed.
     if (hLogModuleFilter.FindString(modulename) < 0)
@@ -402,14 +402,14 @@ bool LogModuleFilterRemove(LogModules module)
     char modulename[64];
     int moduleindex;
 
+    // Convert module name.
+    LogGetModuleNameString(modulename, sizeof(modulename), module, true);
+
     // Check if empty.
     if (strlen(modulename) == 0)
     {
         return false;
     }
-
-    // Convert module name.
-    LogGetModuleNameString(modulename, sizeof(modulename), module, true);
 
     // Get the module index.
     moduleindex = hLogModuleFilter.FindString(modulename);
@@ -540,7 +540,7 @@ public Action Command_LogList(int client, int argc)
     buffer[0] = 0;
 
     // Module status:
-    modulecount = sizeof(LogModuleFilterCache);
+    modulecount = view_as<int>(LogModule_MAXSIZE);
     for (int module = 1; module < modulecount; module++)
     {
         LogGetModuleNameString(modulename, sizeof(modulename), view_as<LogModules>(module));


### PR DESCRIPTION
## Summary
- `zr_log_add_module` / `zr_log_remove_module` were no-ops: `LogModuleFilterAdd`/`LogModuleFilterRemove` checked the module short-name buffer for emptiness *before* it was populated by `LogGetModuleNameString`, so the (always-zeroed) local buffer looked empty and the function returned early every time. No module ever got pushed to (or erased from) the filter list, no matter what `zr_log_list` showed.
- `Command_LogList` iterated one index past the last real module (into the `LogModule_MAXSIZE` sentinel), which has no case in `LogGetModuleNameString`, so the name/short-name buffers kept their previous iteration's contents and the last module row (e.g. "ZTele") printed twice.

## Test plan
- [ ] Compile the plugin and run `zr_log_add_module playerclasses`, then `zr_log_list` and confirm "Player Classes" now shows "On"
- [ ] Run `zr_log_remove_module playerclasses` and confirm it goes back to "Off"
- [ ] Confirm `zr_log_list` no longer prints a duplicate trailing module row

🤖 Generated with [Claude Code](https://claude.com/claude-code)